### PR TITLE
Add support for CoffeeScript

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -31,17 +31,21 @@ module.exports = function(grunt) {
   grunt.registerTask('build',   [
                      'lock',
                      'clean',
+                     // Uncomment this line and `npm install grunt-contrib-coffee --save-dev`
+                     // for CoffeeScript support. See `tasks/options/coffee.js` for more details.
+                     // 'coffee',
+                     'copy:prepare',
                      'transpile',
                      'jshint',
-                     'copy',
+                     'copy:stage',
                      'emberTemplates:compile',
                      'sass:app',
                      'concat',
                      'unlock' ]);
 
   grunt.registerTask('build:debug', [
-                     'copy:vendor',
-                     'build' ]);
+                     'build',
+                     'copy:vendor' ]);
 
   grunt.registerTask('build:dist', [
                      'useminPrepare',

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ which will hopefully lead to some great additions and contributions.
 - browser test
 - headless tests
 - jshint
+- optionally, CoffeeScript compilation. See `Gruntfile.js` to enable this.
  
 ## What does it clearly need to still do
 - **** reduce the hacks needed to make this work ****

--- a/tasks/options/coffee.js
+++ b/tasks/options/coffee.js
@@ -1,0 +1,42 @@
+// CoffeeScript compilation. This must be enabled by modification
+// of Gruntfile.js.
+//
+// The `bare` option is used since this file will be transpiled
+// anyway. In CoffeeScript files, you need to escape out for
+// some ES6 features like import and export. For example:
+//
+// `import 'appkit/models/user' as User`
+//
+// Posts = Em.Object.extend
+//   init: (userId) ->
+//     @set 'user', User.findById(userId)
+//
+// `export = Posts`
+//
+
+module.exports = {
+  "test": {
+    options: {
+      bare: true
+    },
+    files: [{
+      expand: true,
+      cwd: 'tests/',
+      src: ['**/*.coffee', '!vendor/**/*.coffee'],
+      dest: 'tmp/javascript/tests',
+      ext: '.js'
+    }]
+  },
+  "app": {
+    options: {
+      bare: true
+    },
+    files: [{
+      expand: true,
+      cwd: 'app/',
+      src: '**/*.coffee',
+      dest: 'tmp/javascript/app',
+      ext: '.js'
+    }]
+  }
+};

--- a/tasks/options/copy.js
+++ b/tasks/options/copy.js
@@ -1,21 +1,40 @@
 module.exports = {
-  "public": {
+  // These copy tasks happen before transpile or hinting. They
+  // prepare the build pipeline by moving JavaScript files to
+  // tmp/javascript.
+  //
+  "prepare": {
     files: [{
       expand: true,
-      cwd: 'public',
-      src: ['**'],
-      dest: 'tmp/public/'
-    } ]
-  },
-  "tests": {
-    files: [{
+      cwd: 'app/',
+      src: '**/*.js',
+      dest: 'tmp/javascript/app'
+    },
+    {
       expand: true,
-      cwd: 'tests',
-      src: ['index.html', 'test_helper.js', 'vendor/**/*'],
-      dest: 'tmp/public/tests/'
+      cwd: 'tests/',
+      src: ['**/*.js', '!vendor/**/*.js'],
+      dest: 'tmp/javascript/tests/'
     }]
   },
-  vendor: {
+  // Stage moves files to their final destinations after the rest
+  // of the build cycle has run.
+  //
+  "stage": {
+    files: [{
+      expand: true,
+      cwd: 'tests/',
+      src: ['index.html', 'test_helper.js', 'vendor/**/*'],
+      dest: 'tmp/public/tests/'
+    },
+    {
+      expand: true,
+      cwd: 'public/',
+      src: ['**'],
+      dest: 'tmp/public/'
+    }]
+  },
+  "vendor": {
     src: ['vendor/loader.js', 'vendor/jquery-*.js', 'vendor/handlebars.js', 'vendor/**/*.js'],
     dest: 'tmp/public/'
   },

--- a/tasks/options/transpile.js
+++ b/tasks/options/transpile.js
@@ -1,28 +1,28 @@
 var grunt = require('grunt');
 
 module.exports = {
-  test: {
+  "tests": {
     type: 'amd',
     moduleName: function(path) {
       return grunt.config.process('<%= pkg.namespace %>/tests/') + path;
     },
     files: [{
       expand: true,
-      cwd: 'tests/',
-      src: ['**/*.js', '!vendor/**/*.js'],
-      dest: 'tmp/transpiled/tests'
+      cwd: 'tmp/javascript/tests/',
+      src: '**/*.js',
+      dest: 'tmp/transpiled/tests/'
     }]
   },
-  app: {
+  "app": {
     type: 'amd',
     moduleName: function(path) {
       return grunt.config.process('<%= pkg.namespace %>/') + path;
     },
     files: [{
       expand: true,
-      cwd: 'app/',
+      cwd: 'tmp/javascript/app/',
       src: '**/*.js',
-      dest: 'tmp/transpiled/app'
+      dest: 'tmp/transpiled/app/'
     }]
   }
 };


### PR DESCRIPTION
This is a stab at CoffeeScript support. Both tests and the app go through the compiler. Some re-organizing of the copy configuration was required to stage the files for the transpiler step.

For consideration and feedback- It works for me but I doubt this is exactly what you want for CS support? Happy to try and apply any other ideas.
