### PR TITLE
Change build:dist output directory. Fixes #21.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@
 
 # Ignore all logfiles and tempfiles.
 /log/*.log
-/tmp
 /bin
 /bundle
 
@@ -23,3 +22,6 @@
 /vendor/handlebars/
 /vendor/jquery/
 
+# Ignore build directories
+/tmp
+/dist

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,7 +2,6 @@ module.exports = function(grunt) {
   var config = {
     pkg: grunt.file.readJSON('package.json'),
     env: process.env,
-    clean: ['tmp']
   };
 
   grunt.util._.extend(config, loadConfig('./tasks/options/'));
@@ -15,7 +14,7 @@ module.exports = function(grunt) {
   grunt.registerTask('default', "Build (in debug mode) & test your application.", ['build:debug', 'test']);
   grunt.registerTask('build',   [
                      'lock',
-                     'clean',
+                     'clean:build',
                      // Uncomment this line  & `npm install --save-dev grunt-contrib-coffee` for CoffeeScript support.
                      // 'coffee',
                      'copy:prepare',
@@ -38,6 +37,7 @@ module.exports = function(grunt) {
                      'useminPrepare',
                      'build',
                      'uglify',
+                     'copy:dist',
                      'rev',
                      'usemin' ]);
 

--- a/tasks/options/clean.js
+++ b/tasks/options/clean.js
@@ -1,0 +1,4 @@
+module.exports = {
+  "build": ['tmp'],
+  "release": ['dist'],
+}

--- a/tasks/options/copy.js
+++ b/tasks/options/copy.js
@@ -38,4 +38,12 @@ module.exports = {
     src: ['vendor/**/*.js'],
     dest: 'tmp/public/'
   },
+  "dist": {
+    files: [{
+      expand: true,
+      cwd: 'tmp/public',
+      src: ['**', '!coverage'],
+      dest: 'dist/'
+    }]
+  },
 };

--- a/tasks/options/rev.js
+++ b/tasks/options/rev.js
@@ -2,10 +2,10 @@ module.exports = {
   dist: {
     files: {
       src: [
-        'tmp/public/assets/app.min.js',
-        'tmp/public/assets/vendor.min.js',
-        'tmp/public/assets/app.css',
-        'tmp/public/assets/vendor.css'
+        'dist/assets/app.min.js',
+        'dist/assets/vendor.min.js',
+        'dist/assets/app.css',
+        'dist/assets/vendor.css'
       ]
     }
   }

--- a/tasks/options/usemin.js
+++ b/tasks/options/usemin.js
@@ -1,3 +1,3 @@
 module.exports = {
-  html: ['tmp/public/index.html'],
+  html: ['dist/index.html'],
 };

--- a/tasks/options/useminPrepare.js
+++ b/tasks/options/useminPrepare.js
@@ -1,6 +1,6 @@
 module.exports = {
   html: 'public/index.html',
   options: {
-    dest: 'tmp/public/'
+    dest: 'dist/'
   }
 };


### PR DESCRIPTION
I took a stab at updating the build:dist task to use a separate final
output directory. With this PR `dist/` is the final output directory
from running `grunt build:dist`.

Feedback welcome! Please let me know what would make this better.
