### PR TITLE
No need to copy before transpiling.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -18,7 +18,6 @@ module.exports = function(grunt) {
                      'clean',
                      // Uncomment this line  & `npm install --save-dev grunt-contrib-coffee` for CoffeeScript support.
                      // 'coffee',
-                     'copy:prepare',
                      'transpile',
                      'jshint',
                      'copy:stage',

--- a/tasks/options/copy.js
+++ b/tasks/options/copy.js
@@ -1,22 +1,4 @@
 module.exports = {
-  // These copy tasks happen before transpile or hinting. They
-  // prepare the build pipeline by moving JavaScript files to
-  // tmp/javascript.
-  //
-  "prepare": {
-    files: [{
-      expand: true,
-      cwd: 'app/',
-      src: '**/*.js',
-      dest: 'tmp/javascript/app'
-    },
-    {
-      expand: true,
-      cwd: 'tests/',
-      src: ['**/*.js', '!vendor/**/*.js'],
-      dest: 'tmp/javascript/tests/'
-    }]
-  },
   // Stage moves files to their final destinations after the rest
   // of the build cycle has run.
   //

--- a/tasks/options/transpile.js
+++ b/tasks/options/transpile.js
@@ -8,8 +8,8 @@ module.exports = {
     },
     files: [{
       expand: true,
-      cwd: 'tmp/javascript/tests/',
-      src: '**/*.js',
+      cwd: 'tests/',
+      src: ['**/*.js', '!vendor/**/*.js'],
       dest: 'tmp/transpiled/tests/'
     }]
   },
@@ -20,7 +20,7 @@ module.exports = {
     },
     files: [{
       expand: true,
-      cwd: 'tmp/javascript/app/',
+      cwd: 'app/',
       src: '**/*.js',
       dest: 'tmp/transpiled/app/'
     }]


### PR DESCRIPTION
The `transpile` task can read directly from the `app/**/*.js` files so
there is no need for an extra copy step. Removing the extra step will be
helpful in attempting to get real source map support.
