### PR TITLE
use almond module loader

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "ember": "~1.0.0-rc.6",
     "handlebars": "~1.0.0",
-    "jquery": "~1.9.1"
+    "jquery": "~1.9.1",
+    "almond": ">=0.2.5"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,7 @@
   <script src="/vendor/jquery/jquery.js"></script>
   <script src="/vendor/handlebars/handlebars.js"></script>
   <script src="/vendor/ember/ember.js"></script>
+  <script src="/vendor/almond/almond.js"></script>
   <script src="/vendor/loader.js"></script>
   <!-- endbuild -->
 

--- a/vendor/resolver.js
+++ b/vendor/resolver.js
@@ -1,43 +1,3 @@
-var define, requireModule;
-
-(function() {
-  var registry = {}, seen = {};
-
-  define = function(name, deps, callback) {
-    registry[name] = { deps: deps, callback: callback };
-  };
-
-  requireModule = function(name) {
-    if (seen[name]) { return seen[name]; }
-    seen[name] = {};
-
-    var mod = registry[name];
-
-    if (!mod) {
-      throw new Error("Module: '" + name + "' not found.");
-    }
-
-    var deps = mod.deps,
-        callback = mod.callback,
-        reified = [],
-        exports;
-
-    for (var i=0, l=deps.length; i<l; i++) {
-      if (deps[i] === 'exports') {
-        reified.push(exports = {});
-      } else {
-        reified.push(requireModule(deps[i]));
-      }
-    }
-
-    var value = callback.apply(this, reified);
-    return seen[name] = exports || value;
-  };
-
-  define.registry = registry;
-  define.seen = seen;
-})();
-
 define("resolver",
   [],
   function() {
@@ -87,8 +47,14 @@ define("resolver",
     var moduleName = prefix + '/' +  pluralizedType + '/' + underscore(name);
     var module;
 
-    if (define.registry[moduleName]) {
-      module = requireModule(moduleName);
+    // need define.registry in almond to get rid of this mess
+    try {
+      module = require(moduleName);
+    } catch(e) {}
+
+    //if (define.registry[moduleName]) {
+    if (module) {
+      //module = require(moduleName);
 
       if (typeof module.create !== 'function') {
         module = classFactory(module);


### PR DESCRIPTION
This allows us to use other AMD or ES6->AMD
modules outside of the ember application objects.

For example, to use the moment date library:
1. Add it to bower.json and bower install
2. Add it to index.html with other vendor scripts
   (we should change this too)
3. In your code `import moment from 'moment';`

Note: renamed loader.js to resolver.js because
it doesn't do the loading anymore, just the
resolving.
