### PR TITLE
[fixes #44] Changed QUnit harness to use correct handlebars file.

### DIFF
--- a/tests/index.html
+++ b/tests/index.html
@@ -23,7 +23,7 @@
   </style>
 
   <script src="/vendor/jquery/jquery.js"></script>
-  <script src="/vendor/handlebars/handlebars.runtime.js"></script>
+  <script src="/vendor/handlebars/handlebars.js"></script>
   <script src="/vendor/ember/ember.js"></script>
   <script src="/vendor/loader.js"></script>
 


### PR DESCRIPTION
QUnit runner was failing because it referenced a non-existent handlebars file. Updated to use the file in the handlebars folder and the tests pass.
