### PR TITLE
Ignore lockfile and Karma logfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@
 /node_modules
 /.sass-cache
 
+/connect.lock
+/libpeerconnection.log
+
 /vendor/ember/
 /vendor/handlebars/
 /vendor/jquery/


### PR DESCRIPTION
Small thing- connect.lock and libpeerconnection.log should be ignored.
