### PR TITLE
Add a fallback route to index.html in development

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ For usage information, please see the [getting started guide](https://github.com
 - Testing via QUnit, Ember Testing, and Karma
 - Linting source via JSHint (including module syntax)
 - Project compilation & minification for easy deploys
+- Catch-all index.html for easy reloading of pushState router apps
 - Optional CoffeeScript, SASS, and LESS support
 - Optional support for package management via [bower](https://github.com/bower/bower)
 

--- a/tasks/options/connect.js
+++ b/tasks/options/connect.js
@@ -1,4 +1,6 @@
-var lockFile = require('lockfile')
+var lockFile = require('lockfile'),
+    fs = require('fs'),
+    url = require('url');
 
 module.exports = {
   server: {
@@ -6,6 +8,9 @@ module.exports = {
       port: process.env.PORT || 8000,
       hostname: '0.0.0.0',
       base: 'tmp/public',
+      // Use this option to have the catch-all return a different
+      // page than index.html on any url not matching an asset.
+      //   wildcard: 'not_index.html'
       middleware: middleware
     }
   }
@@ -22,10 +27,28 @@ function lock(req, res, next) {
   }());
 }
 
+function buildWildcardMiddleware(options) {
+  return function(req, res, next) {
+    if ('GET' != req.method.toUpperCase() && 'HEAD' != req.method.toUpperCase()) { return next();  }
+
+    var wildcard     = (options.wildcard || 'index.html'),
+        wildcardPath = options.base + "/" + wildcard;
+
+    fs.readFile(wildcardPath, function(err, data){
+      if (err) { return next('ENOENT' == err.code ? null : err); }
+
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end(data);
+    });
+  }
+}
+
 function middleware(connect, options) {
   return [
     lock,
     connect['static'](options.base),
-    connect.directory(options.base)
+    connect.directory(options.base),
+    // Remove this middleware to disable catch-all routing.
+    buildWildcardMiddleware(options)
   ];
 }


### PR DESCRIPTION
Ember apps are single-page. Ember appkit requires that you enter the app via index.html or another pre-defined file in public. If you have dynamic URLs, this sucks. You can't just reload a page and be back at the state you were in a moment before.

This adds wildcard middleware to connect. If a file/directory cannot be loaded via the traditional pipeline, then the wildcard picks it up and tries to return index.html or another file configured as the `wildcard` property on the connect options.

So reload that dynamic URL at will, ye masters of Ember.

@stefanpenner, I'm not sure if maybe you had another idea on how to solve this? Or if you solve it elsewhere? IMO this is a good start.
