### PR TITLE
Exclude `test_helper.js` and `test_loader.js`

### DIFF
--- a/tasks/options/copy.js
+++ b/tasks/options/copy.js
@@ -13,7 +13,7 @@ module.exports = {
     {
       expand: true,
       cwd: 'tests/',
-      src: ['**/*.js', '!vendor/**/*.js'],
+      src: ['**/*.js', '!test_helper.js', '!test_loader.js', '!vendor/**/*.js'],
       dest: 'tmp/javascript/tests/'
     }]
   },


### PR DESCRIPTION
Both the files are included separately. No need to transpiled and added
to `tests.js`
