### PR TITLE
Reset Ember dependency to rc.6

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-app-kit",
   "dependencies": {
-    "ember": "~1.0.0-rc.6.1",
+    "ember": "~1.0.0-rc.6",
     "handlebars": "~1.0.0",
     "jquery": "~1.9.1"
   }


### PR DESCRIPTION
According to [the Ember components repository](https://github.com/components/ember), which is where Bower looks for Ember, it hasn't updated to rc.6.1 yet. Resetting this so those getting started with EAK don't have to troubleshoot this error until components updates.
