### PR TITLE
Fix QUnit output for equal assertions

### DIFF
--- a/tests/test_helper.js
+++ b/tests/test_helper.js
@@ -12,7 +12,13 @@ function exists(selector) {
   return !!find(selector).length;
 }
 
+function equal(actual, expected, message) {
+  message = message || QUnit.jsDump.parse(expected) + " expected but was " + QUnit.jsDump.parse(actual);
+  QUnit.equal.call(this, expected, actual, message);
+}
+
 window.exists = exists;
+window.equal = equal;
 
 Ember.Container.prototype.stub = function(fullName, instance) {
   instance.destroy = instance.destroy || function() {};


### PR DESCRIPTION
Display a friendlier message than 'undefined' when an equal assertion fails.
