### PR TITLE
Fix vendored file versions.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,8 @@
 {
   "name": "ember-app-kit",
   "dependencies": {
-    "ember": "~1.0.0-rc.6",
-    "handlebars": "~1.0.0",
+    "ember": "~1.0.0-rc.6.1",
+    "handlebars": "~1.0.0-rc.4",
     "jquery": "~1.9.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "grunt-usemin": "~0.1.12",
     "grunt-contrib-uglify": "~0.2.2",
     "grunt-rev": "~0.1.0",
-    "grunt-ember-templates": "0.4.10",
+    "grunt-ember-templates": "0.4.9",
     "string": "~1.4.0",
     "karma": "~0.9.4",
     "grunt-karma": "~0.5",

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
 
   <!-- build:js(.) assets/vendor.min.js -->
   <script src="/vendor/jquery/jquery.js"></script>
-  <script src="/vendor/handlebars/handlebars.js"></script>
+  <script src="/vendor/handlebars/handlebars.runtime.js"></script>
   <script src="/vendor/ember/ember.js"></script>
   <script src="/vendor/loader.js"></script>
   <!-- endbuild -->

--- a/tests/index.html
+++ b/tests/index.html
@@ -23,7 +23,7 @@
   </style>
 
   <script src="/vendor/jquery/jquery.js"></script>
-  <script src="/vendor/handlebars/handlebars.js"></script>
+  <script src="/vendor/handlebars/handlebars.runtime.js"></script>
   <script src="/vendor/ember/ember.js"></script>
   <script src="/vendor/loader.js"></script>
 

--- a/vendor/ember/ember.js
+++ b/vendor/ember/ember.js
@@ -1,5 +1,5 @@
-// Version: v1.0.0-rc.6-155-g6754343
-// Last commit: 6754343 (2013-07-20 06:18:24 -0700)
+// Version: v1.0.0-rc.6.1
+// Last commit: 2a9ce26 (2013-07-25 18:13:33 -0400)
 
 
 (function() {
@@ -156,8 +156,8 @@ Ember.deprecateFunc = function(message, func) {
 
 })();
 
-// Version: v1.0.0-rc.6-155-g6754343
-// Last commit: 6754343 (2013-07-20 06:18:24 -0700)
+// Version: v1.0.0-rc.6-2-gaa6f429
+// Last commit: aa6f429 (2013-07-25 20:20:00 -0400)
 
 
 (function() {
@@ -354,19 +354,16 @@ Ember.uuid = 0;
 //
 
 function consoleMethod(name) {
-  var console = imports.console,
-      method = typeof console === 'object' ? console[name] : null;
-
-  if (method) {
+  if (imports.console && imports.console[name]) {
     // Older IE doesn't support apply, but Chrome needs it
-    if (method.apply) {
+    if (imports.console[name].apply) {
       return function() {
-        method.apply(console, arguments);
+        imports.console[name].apply(imports.console, arguments);
       };
     } else {
       return function() {
         var message = Array.prototype.join.call(arguments, ', ');
-        method(message);
+        imports.console[name](message);
       };
     }
   }
@@ -378,7 +375,7 @@ function assertPolyfill(test, message) {
       // attempt to preserve the stack
       throw new Error("assertion failed: " + message);
     } catch(error) {
-      setTimeout(function() {
+      setTimeout(function(){
         throw error;
       }, 0);
     }
@@ -460,7 +457,7 @@ Ember.merge = function(original, updates) {
   Ember.isNone(undefined);     // true
   Ember.isNone('');            // false
   Ember.isNone([]);            // false
-  Ember.isNone(function() {});  // false
+  Ember.isNone(function(){});  // false
   ```
 
   @method isNone
@@ -565,7 +562,7 @@ var canRedefineProperties, canDefinePropertyOnDOM;
 // Catch IE8 where Object.defineProperty exists but only works on DOM elements
 if (defineProperty) {
   try {
-    defineProperty({}, 'a',{get:function() {}});
+    defineProperty({}, 'a',{get:function(){}});
   } catch (e) {
     defineProperty = null;
   }
@@ -596,7 +593,7 @@ if (defineProperty) {
 
   // This is for Safari 5.0, which supports Object.defineProperty, but not
   // on DOM nodes.
-  canDefinePropertyOnDOM = (function() {
+  canDefinePropertyOnDOM = (function(){
     try {
       defineProperty(document.createElement('div'), 'definePropertyOnDOM', {});
       return true;
@@ -608,7 +605,7 @@ if (defineProperty) {
   if (!canRedefineProperties) {
     defineProperty = null;
   } else if (!canDefinePropertyOnDOM) {
-    defineProperty = function(obj, keyName, desc) {
+    defineProperty = function(obj, keyName, desc){
       var isNode;
 
       if (typeof Node === "object") {
@@ -1201,9 +1198,9 @@ var needsFinallyFix = (function() {
   @for Ember
   @param {Function} tryable The function to run the try callback
   @param {Function} finalizer The function to run the finally callback
-  @param {Object} [binding] The optional calling object. Defaults to 'this'
+  @param [binding]
   @return {*} The return value is the that of the finalizer,
-  unless that value is undefined, in which case it is the return value
+  unless that valueis undefined, in which case it is the return value
   of the tryable
 */
 
@@ -1218,7 +1215,7 @@ if (needsFinallyFix) {
     } finally {
       try {
         finalResult = finalizer.call(binding);
-      } catch (e) {
+      } catch (e){
         finalError = e;
       }
     }
@@ -1252,7 +1249,7 @@ if (needsFinallyFix) {
   @param {Function} tryable The function to run the try callback
   @param {Function} catchable The function to run the catchable callback
   @param {Function} finalizer The function to run the finally callback
-  @param {Object} [binding] The optional calling object. Defaults to 'this'
+  @param [binding]
   @return {*} The return value is the that of the finalizer,
   unless that value is undefined, in which case it is the return value
   of the tryable.
@@ -1270,7 +1267,7 @@ if (needsFinallyFix) {
     } finally {
       try {
         finalResult = finalizer.call(binding);
-      } catch (e) {
+      } catch (e){
         finalError = e;
       }
     }
@@ -1469,7 +1466,7 @@ Ember.Instrumentation.instrument = function(name, payload, callback, binding) {
 
   var beforeValues = [], listener, i, l;
 
-  function tryable() {
+  function tryable(){
     for (i=0, l=listeners.length; i<l; i++) {
       listener = listeners[i];
       beforeValues[i] = listener.before(name, time(), payload);
@@ -1478,7 +1475,7 @@ Ember.Instrumentation.instrument = function(name, payload, callback, binding) {
     return callback.call(binding);
   }
 
-  function catchable(e) {
+  function catchable(e){
     payload = payload || {};
     payload.exception = e;
   }
@@ -1997,10 +1994,14 @@ function suspendListener(obj, eventName, target, method, callback) {
 /**
   @private
 
-  Suspends multiple listeners during a callback.
+  Suspend listener during callback.
 
-  
-  @method suspendListeners
+  This should only be used by the target of the event listener
+  when it is taking an action that would cause the event, e.g.
+  an object might suspend its property change listener while it is
+  setting that property.
+
+  @method suspendListener
   @for Ember
   @param obj
   @param {Array} eventName Array of event names
@@ -2062,17 +2063,12 @@ function watchedEvents(obj) {
 }
 
 /**
-  Send an event. The execution of suspended listeners
-  is skipped, and once listeners are removed. A listener without
-  a target is executed on the passed object. If an array of actions
-  is not passed, the actions stored on the passed object are invoked.
-  
   @method sendEvent
   @for Ember
   @param obj
   @param {String} eventName
-  @param {Array} params Optional parameters for each listener.
-  @param {Array} actions Optional array of actions (listeners).
+  @param {Array} params
+  @param {Array} actions
   @return true
 */
 function sendEvent(obj, eventName, params, actions) {
@@ -2406,7 +2402,7 @@ var endPropertyChanges = Ember.endPropertyChanges = function() {
   @param {Function} callback
   @param [binding]
 */
-Ember.changeProperties = function(cb, binding) {
+Ember.changeProperties = function(cb, binding){
   beginPropertyChanges();
   tryFinally(cb, endPropertyChanges, binding);
 };
@@ -2435,7 +2431,6 @@ var notifyObservers = function(obj, keyName) {
     sendEvent(obj, eventName, [obj, keyName]);
   }
 };
-
 })();
 
 
@@ -2612,7 +2607,8 @@ Ember.trySetPath = Ember.deprecateFunc('trySetPath has been renamed to trySet', 
   Map is mocked out to look like an Ember object, so you can do
   `Ember.Map.create()` for symmetry with other Ember classes.
 */
-var set = Ember.set,
+var get = Ember.get,
+    set = Ember.set,
     guidFor = Ember.guidFor,
     indexOf = Ember.ArrayPolyfills.indexOf;
 
@@ -3138,14 +3134,13 @@ var changeProperties = Ember.changeProperties,
   @return self
 */
 Ember.setProperties = function(self, hash) {
-  changeProperties(function() {
+  changeProperties(function(){
     for(var prop in hash) {
       if (hash.hasOwnProperty(prop)) { set(self, prop, hash[prop]); }
     }
   });
   return self;
 };
-
 })();
 
 
@@ -4002,7 +3997,7 @@ ComputedPropertyPrototype.set = function(obj, keyName, value) {
       oldSuspended = this._suspended,
       hadCachedValue = false,
       cache = meta.cache,
-      funcArgLength, cachedValue, ret;
+      cachedValue, ret;
 
   if (this._readOnly) {
     throw new Error('Cannot Set: ' + keyName + ' on: ' + obj.toString() );
@@ -4017,18 +4012,17 @@ ComputedPropertyPrototype.set = function(obj, keyName, value) {
       hadCachedValue = true;
     }
 
-    // Check if the CP has been wrapped. If if has, use the
-    // length from the wrapped function.
-    funcArgLength = (func.wrappedFunction ? func.wrappedFunction.length : func.length);
+    // Check if the CP has been wrapped
+    if (func.wrappedFunction) { func = func.wrappedFunction; }
 
     // For backwards-compatibility with computed properties
     // that check for arguments.length === 2 to determine if
     // they are being get or set, only pass the old cached
     // value if the computed property opts into a third
     // argument.
-    if (funcArgLength === 3) {
+    if (func.length === 3) {
       ret = func.call(obj, keyName, value, cachedValue);
-    } else if (funcArgLength === 2) {
+    } else if (func.length === 2) {
       ret = func.call(obj, keyName, value);
     } else {
       Ember.defineProperty(obj, keyName, null, cachedValue);
@@ -4102,7 +4096,7 @@ Ember.computed = function(func) {
     func = a_slice.call(arguments, -1)[0];
   }
 
-  if (typeof func !== "function") {
+  if ( typeof func !== "function" ) {
     throw new Error("Computed Property declared without a property function");
   }
 
@@ -4192,7 +4186,7 @@ registerComputed('notEmpty', function(dependentKey) {
   @for Ember
   @param {String} dependentKey
   @return {Ember.ComputedProperty} computed property which
-  returns true if original value for property is null or undefined.
+  rturns true if original value for property is null or undefined.
 */
 registerComputed('none', function(dependentKey) {
   return Ember.isNone(get(this, dependentKey));
@@ -4370,7 +4364,7 @@ registerComputedWithProperties('map', function(properties) {
   alias to the original value for property.
 */
 Ember.computed.alias = function(dependentKey) {
-  return Ember.computed(dependentKey, function(key, value) {
+  return Ember.computed(dependentKey, function(key, value){
     if (arguments.length > 1) {
       set(this, dependentKey, value);
       return value;
@@ -4547,220 +4541,6 @@ Ember.removeBeforeObserver = function(obj, path, target, method) {
 
 
 (function() {
-define("backburner/queue",
-  ["exports"],
-  function(__exports__) {
-    "use strict";
-    function Queue(daq, name, options) {
-      this.daq = daq;
-      this.name = name;
-      this.options = options;
-      this._queue = [];
-    }
-
-    Queue.prototype = {
-      daq: null,
-      name: null,
-      options: null,
-      _queue: null,
-
-      push: function(target, method, args, stack) {
-        var queue = this._queue;
-        queue.push(target, method, args, stack);
-        return {queue: this, target: target, method: method};
-      },
-
-      pushUnique: function(target, method, args, stack) {
-        var queue = this._queue, currentTarget, currentMethod, i, l;
-
-        for (i = 0, l = queue.length; i < l; i += 4) {
-          currentTarget = queue[i];
-          currentMethod = queue[i+1];
-
-          if (currentTarget === target && currentMethod === method) {
-            queue[i+2] = args; // replace args
-            queue[i+3] = stack; // replace stack
-            return {queue: this, target: target, method: method}; // TODO: test this code path
-          }
-        }
-
-        this._queue.push(target, method, args, stack);
-        return {queue: this, target: target, method: method};
-      },
-
-      // TODO: remove me, only being used for Ember.run.sync
-      flush: function() {
-        var queue = this._queue,
-            options = this.options,
-            before = options && options.before,
-            after = options && options.after,
-            target, method, args, stack, i, l = queue.length;
-
-        if (l && before) { before(); }
-        for (i = 0; i < l; i += 4) {
-          target = queue[i];
-          method = queue[i+1];
-          args   = queue[i+2];
-          stack  = queue[i+3]; // Debugging assistance
-
-          // TODO: error handling
-          if (args && args.length > 0) {
-            method.apply(target, args);
-          } else {
-            method.call(target);
-          }
-        }
-        if (l && after) { after(); }
-
-        // check if new items have been added
-        if (queue.length > l) {
-          this._queue = queue.slice(l);
-          this.flush();
-        } else {
-          this._queue.length = 0;
-        }
-      },
-
-      cancel: function(actionToCancel) {
-        var queue = this._queue, currentTarget, currentMethod, i, l;
-
-        for (i = 0, l = queue.length; i < l; i += 4) {
-          currentTarget = queue[i];
-          currentMethod = queue[i+1];
-
-          if (currentTarget === actionToCancel.target && currentMethod === actionToCancel.method) {
-            queue.splice(i, 4);
-            return true;
-          }
-        }
-
-        // if not found in current queue
-        // could be in the queue that is being flushed
-        queue = this._queueBeingFlushed;
-        if (!queue) {
-          return;
-        }
-        for (i = 0, l = queue.length; i < l; i += 4) {
-          currentTarget = queue[i];
-          currentMethod = queue[i+1];
-
-          if (currentTarget === actionToCancel.target && currentMethod === actionToCancel.method) {
-            // don't mess with array during flush
-            // just nullify the method
-            queue[i+1] = null;
-            return true;
-          }
-        }
-      }
-    };
-
-
-    __exports__.Queue = Queue;
-  });
-
-define("backburner/deferred_action_queues",
-  ["backburner/queue","exports"],
-  function(__dependency1__, __exports__) {
-    "use strict";
-    var Queue = __dependency1__.Queue;
-
-    function DeferredActionQueues(queueNames, options) {
-      var queues = this.queues = {};
-      this.queueNames = queueNames = queueNames || [];
-
-      var queueName;
-      for (var i = 0, l = queueNames.length; i < l; i++) {
-        queueName = queueNames[i];
-        queues[queueName] = new Queue(this, queueName, options[queueName]);
-      }
-    }
-
-    DeferredActionQueues.prototype = {
-      queueNames: null,
-      queues: null,
-
-      schedule: function(queueName, target, method, args, onceFlag, stack) {
-        var queues = this.queues,
-            queue = queues[queueName];
-
-        if (!queue) { throw new Error("You attempted to schedule an action in a queue (" + queueName + ") that doesn't exist"); }
-
-        if (onceFlag) {
-          return queue.pushUnique(target, method, args, stack);
-        } else {
-          return queue.push(target, method, args, stack);
-        }
-      },
-
-      flush: function() {
-        var queues = this.queues,
-            queueNames = this.queueNames,
-            queueName, queue, queueItems, priorQueueNameIndex,
-            queueNameIndex = 0, numberOfQueues = queueNames.length;
-
-        outerloop:
-        while (queueNameIndex < numberOfQueues) {
-          queueName = queueNames[queueNameIndex];
-          queue = queues[queueName];
-          queueItems = queue._queueBeingFlushed = queue._queue.slice();
-          queue._queue = [];
-
-          var options = queue.options,
-              before = options && options.before,
-              after = options && options.after,
-              target, method, args, stack,
-              queueIndex = 0, numberOfQueueItems = queueItems.length;
-
-          if (numberOfQueueItems && before) { before(); }
-          while (queueIndex < numberOfQueueItems) {
-            target = queueItems[queueIndex];
-            method = queueItems[queueIndex+1];
-            args   = queueItems[queueIndex+2];
-            stack  = queueItems[queueIndex+3]; // Debugging assistance
-
-            if (typeof method === 'string') { method = target[method]; }
-
-            // method could have been nullified / canceled during flush
-            if (method) {
-              // TODO: error handling
-              if (args && args.length > 0) {
-                method.apply(target, args);
-              } else {
-                method.call(target);
-              }
-            }
-
-            queueIndex += 4;
-          }
-          queue._queueBeingFlushed = null;
-          if (numberOfQueueItems && after) { after(); }
-
-          if ((priorQueueNameIndex = indexOfPriorQueueWithActions(this, queueNameIndex)) !== -1) {
-            queueNameIndex = priorQueueNameIndex;
-            continue outerloop;
-          }
-
-          queueNameIndex++;
-        }
-      }
-    };
-
-    function indexOfPriorQueueWithActions(daq, currentQueueIndex) {
-      var queueName, queue;
-
-      for (var i = 0, l = currentQueueIndex; i <= l; i++) {
-        queueName = daq.queueNames[i];
-        queue = daq.queues[queueName];
-        if (queue._queue.length) { return i; }
-      }
-
-      return -1;
-    }
-
-
-    __exports__.DeferredActionQueues = DeferredActionQueues;
-  });
-
 define("backburner",
   ["backburner/deferred_action_queues","exports"],
   function(__dependency1__, __exports__) {
@@ -4769,11 +4549,9 @@ define("backburner",
 
     var slice = [].slice,
         pop = [].pop,
-        throttlers = [],
         debouncees = [],
         timers = [],
-        autorun, laterTimer, laterTimerExpiresAt,
-        global = this;
+        autorun, laterTimer, laterTimerExpiresAt;
 
     function Backburner(queueNames, options) {
       this.queueNames = queueNames;
@@ -4930,7 +4708,7 @@ define("backburner",
           clearTimeout(laterTimer);
           laterTimer = null;
         }
-        laterTimer = global.setTimeout(function() {
+        laterTimer = window.setTimeout(function() {
           executeTimers(self);
           laterTimer = null;
           laterTimerExpiresAt = null;
@@ -4940,86 +4718,38 @@ define("backburner",
         return fn;
       },
 
-      throttle: function(target, method /* , args, wait */) {
+      debounce: function(target, method /* , args, wait */) {
         var self = this,
             args = arguments,
             wait = pop.call(args),
-            throttler;
+            debouncee;
 
-        for (var i = 0, l = throttlers.length; i < l; i++) {
-          throttler = throttlers[i];
-          if (throttler[0] === target && throttler[1] === method) { return; } // do nothing
+        for (var i = 0, l = debouncees.length; i < l; i++) {
+          debouncee = debouncees[i];
+          if (debouncee[0] === target && debouncee[1] === method) { return; } // do nothing
         }
 
-        var timer = global.setTimeout(function() {
+        var timer = window.setTimeout(function() {
           self.run.apply(self, args);
 
-          // remove throttler
+          // remove debouncee
           var index = -1;
-          for (var i = 0, l = throttlers.length; i < l; i++) {
-            throttler = throttlers[i];
-            if (throttler[0] === target && throttler[1] === method) {
+          for (var i = 0, l = debouncees.length; i < l; i++) {
+            debouncee = debouncees[i];
+            if (debouncee[0] === target && debouncee[1] === method) {
               index = i;
               break;
             }
           }
 
-          if (index > -1) { throttlers.splice(index, 1); }
+          if (index > -1) { debouncees.splice(index, 1); }
         }, wait);
-
-        throttlers.push([target, method, timer]);
-      },
-
-      debounce: function(target, method /* , args, wait, [immediate] */) {
-        var self = this,
-            args = arguments,
-            immediate = pop.call(args),
-            wait,
-            index,
-            debouncee;
-
-        if (typeof immediate === "number") {
-          wait = immediate;
-          immediate = false;
-        } else {
-          wait = pop.call(args);
-        }
-
-        // Remove debouncee
-        index = findDebouncee(target, method);
-
-        if (index !== -1) {
-          debouncee = debouncees[index];
-          debouncees.splice(index, 1);
-          clearTimeout(debouncee[2]);
-        }
-
-        var timer = window.setTimeout(function() {
-          if (!immediate) {
-            self.run.apply(self, args);
-          }
-          index = findDebouncee(target, method);
-          if (index) {
-            debouncees.splice(index, 1);
-          }
-        }, wait);
-
-        if (immediate && index === -1) {
-          self.run.apply(self, args);
-        }
 
         debouncees.push([target, method, timer]);
       },
 
       cancelTimers: function() {
-        var i, len;
-
-        for (i = 0, len = throttlers.length; i < len; i++) {
-          clearTimeout(throttlers[i][2]);
-        }
-        throttlers = [];
-
-        for (i = 0, len = debouncees.length; i < len; i++) {
+        for (var i = 0, l = debouncees.length; i < l; i++) {
           clearTimeout(debouncees[i][2]);
         }
         debouncees = [];
@@ -5062,7 +4792,7 @@ define("backburner",
 
     function createAutorun(backburner) {
       backburner.begin();
-      autorun = global.setTimeout(function() {
+      autorun = window.setTimeout(function() {
         backburner.end();
         autorun = null;
       });
@@ -5087,7 +4817,7 @@ define("backburner",
       });
 
       if (timers.length) {
-        laterTimer = global.setTimeout(function() {
+        laterTimer = window.setTimeout(function() {
           executeTimers(self);
           laterTimer = null;
           laterTimerExpiresAt = null;
@@ -5096,23 +4826,222 @@ define("backburner",
       }
     }
 
-    function findDebouncee(target, method) {
-      var debouncee,
-          index = -1;
 
-      for (var i = 0, l = debouncees.length; i < l; i++) {
-        debouncee = debouncees[i];
-        if (debouncee[0] === target && debouncee[1] === method) {
-          index = i;
-          break;
+    __exports__.Backburner = Backburner;
+  });
+
+define("backburner/deferred_action_queues",
+  ["backburner/queue","exports"],
+  function(__dependency1__, __exports__) {
+    "use strict";
+    var Queue = __dependency1__.Queue;
+
+    function DeferredActionQueues(queueNames, options) {
+      var queues = this.queues = {};
+      this.queueNames = queueNames = queueNames || [];
+
+      var queueName;
+      for (var i = 0, l = queueNames.length; i < l; i++) {
+        queueName = queueNames[i];
+        queues[queueName] = new Queue(this, queueName, options[queueName]);
+      }
+    }
+
+    DeferredActionQueues.prototype = {
+      queueNames: null,
+      queues: null,
+
+      schedule: function(queueName, target, method, args, onceFlag, stack) {
+        var queues = this.queues,
+            queue = queues[queueName];
+
+        if (!queue) { throw new Error("You attempted to schedule an action in a queue (" + queueName + ") that doesn't exist"); }
+
+        if (onceFlag) {
+          return queue.pushUnique(target, method, args, stack);
+        } else {
+          return queue.push(target, method, args, stack);
+        }
+      },
+
+      flush: function() {
+        var queues = this.queues,
+            queueNames = this.queueNames,
+            queueName, queue, queueItems, priorQueueNameIndex,
+            queueNameIndex = 0, numberOfQueues = queueNames.length;
+
+        outerloop:
+        while (queueNameIndex < numberOfQueues) {
+          queueName = queueNames[queueNameIndex];
+          queue = queues[queueName];
+          queueItems = queue._queueBeingFlushed = queue._queue.slice();
+          queue._queue = [];
+
+          var options = queue.options,
+              before = options && options.before,
+              after = options && options.after,
+              target, method, args, stack,
+              queueIndex = 0, numberOfQueueItems = queueItems.length;
+
+          if (numberOfQueueItems && before) { before(); }
+          while (queueIndex < numberOfQueueItems) {
+            target = queueItems[queueIndex];
+            method = queueItems[queueIndex+1];
+            args   = queueItems[queueIndex+2];
+            stack  = queueItems[queueIndex+3]; // Debugging assistance
+
+            if (typeof method === 'string') { method = target[method]; }
+
+            // method could have been nullified / canceled during flush
+            if (method) {
+              // TODO: error handling
+              if (args && args.length > 0) {
+                method.apply(target, args);
+              } else {
+                method.call(target);
+              }
+            }
+
+            queueIndex += 4;
+          }
+          queue._queueBeingFlushed = null;
+          if (numberOfQueueItems && after) { after(); }
+
+          if ((priorQueueNameIndex = indexOfPriorQueueWithActions(this, queueNameIndex)) !== -1) {
+            queueNameIndex = priorQueueNameIndex;
+            continue outerloop;
+          }
+
+          queueNameIndex++;
         }
       }
+    };
 
-      return index;
+    function indexOfPriorQueueWithActions(daq, currentQueueIndex) {
+      var queueName, queue;
+
+      for (var i = 0, l = currentQueueIndex; i <= l; i++) {
+        queueName = daq.queueNames[i];
+        queue = daq.queues[queueName];
+        if (queue._queue.length) { return i; }
+      }
+
+      return -1;
     }
 
 
-    __exports__.Backburner = Backburner;
+    __exports__.DeferredActionQueues = DeferredActionQueues;
+  });
+
+define("backburner/queue",
+  ["exports"],
+  function(__exports__) {
+    "use strict";
+    function Queue(daq, name, options) {
+      this.daq = daq;
+      this.name = name;
+      this.options = options;
+      this._queue = [];
+    }
+
+    Queue.prototype = {
+      daq: null,
+      name: null,
+      options: null,
+      _queue: null,
+
+      push: function(target, method, args, stack) {
+        var queue = this._queue;
+        queue.push(target, method, args, stack);
+        return {queue: this, target: target, method: method};
+      },
+
+      pushUnique: function(target, method, args, stack) {
+        var queue = this._queue, currentTarget, currentMethod, i, l;
+
+        for (i = 0, l = queue.length; i < l; i += 4) {
+          currentTarget = queue[i];
+          currentMethod = queue[i+1];
+
+          if (currentTarget === target && currentMethod === method) {
+            queue[i+2] = args; // replace args
+            queue[i+3] = stack; // replace stack
+            return {queue: this, target: target, method: method}; // TODO: test this code path
+          }
+        }
+
+        this._queue.push(target, method, args, stack);
+        return {queue: this, target: target, method: method};
+      },
+
+      // TODO: remove me, only being used for Ember.run.sync
+      flush: function() {
+        var queue = this._queue,
+            options = this.options,
+            before = options && options.before,
+            after = options && options.after,
+            target, method, args, stack, i, l = queue.length;
+
+        if (l && before) { before(); }
+        for (i = 0; i < l; i += 4) {
+          target = queue[i];
+          method = queue[i+1];
+          args   = queue[i+2];
+          stack  = queue[i+3]; // Debugging assistance
+
+          // TODO: error handling
+          if (args && args.length > 0) {
+            method.apply(target, args);
+          } else {
+            method.call(target);
+          }
+        }
+        if (l && after) { after(); }
+
+        // check if new items have been added
+        if (queue.length > l) {
+          this._queue = queue.slice(l);
+          this.flush();
+        } else {
+          this._queue.length = 0;
+        }
+      },
+
+      cancel: function(actionToCancel) {
+        var queue = this._queue, currentTarget, currentMethod, i, l;
+
+        for (i = 0, l = queue.length; i < l; i += 4) {
+          currentTarget = queue[i];
+          currentMethod = queue[i+1];
+
+          if (currentTarget === actionToCancel.target && currentMethod === actionToCancel.method) {
+            queue.splice(i, 4);
+            return true;
+          }
+        }
+
+        // if not found in current queue
+        // could be in the queue that is being flushed
+        queue = this._queueBeingFlushed;
+        if (!queue) {
+          return;
+        }
+        for (i = 0, l = queue.length; i < l; i += 4) {
+          currentTarget = queue[i];
+          currentMethod = queue[i+1];
+
+          if (currentTarget === actionToCancel.target && currentMethod === actionToCancel.method) {
+            // don't mess with array during flush
+            // just nullify the method
+            queue[i+1] = null;
+            return true;
+          }
+        }
+      }
+    };
+
+
+    __exports__.Queue = Queue;
   });
 })();
 
@@ -5154,7 +5083,7 @@ var Backburner = requireModule('backburner').Backburner,
   call.
 
   ```javascript
-  Ember.run(function() {
+  Ember.run(function(){
     // code to be execute within a RunLoop
   });
   ```
@@ -5197,7 +5126,7 @@ Ember.run = function(target, method) {
   If invoked when not within a run loop:
 
   ```javascript
-  Ember.run.join(function() {
+  Ember.run.join(function(){
     // creates a new run-loop
   });
   ```
@@ -5205,9 +5134,9 @@ Ember.run = function(target, method) {
   Alternatively, if called within an existing run loop:
 
   ```javascript
-  Ember.run(function() {
+  Ember.run(function(){
     // creates a new run-loop
-    Ember.run.join(function() {
+    Ember.run.join(function(){
       // joins with the existing run-loop, and queues for invocation on
       // the existing run-loops action queue.
     });
@@ -5300,12 +5229,12 @@ Ember.run.end = function() {
   the `Ember.run.queues` property.
 
   ```javascript
-  Ember.run.schedule('sync', this, function() {
+  Ember.run.schedule('sync', this, function(){
     // this will be executed in the first RunLoop queue, when bindings are synced
     console.log("scheduled on sync queue");
   });
 
-  Ember.run.schedule('actions', this, function() {
+  Ember.run.schedule('actions', this, function(){
     // this will be executed in the 'actions' queue, after bindings have synced.
     console.log("scheduled on actions queue");
   });
@@ -5373,7 +5302,7 @@ Ember.run.sync = function() {
   together, which is often more efficient than using a real setTimeout.
 
   ```javascript
-  Ember.run.later(myContext, function() {
+  Ember.run.later(myContext, function(){
     // code here will execute within a RunLoop in about 500ms with this == myContext
   }, 500);
   ```
@@ -5421,11 +5350,11 @@ Ember.run.once = function(target, method) {
   calls.
 
   ```javascript
-  Ember.run(function() {
+  Ember.run(function(){
     var sayHi = function() { console.log('hi'); }
     Ember.run.scheduleOnce('afterRender', myContext, sayHi);
     Ember.run.scheduleOnce('afterRender', myContext, sayHi);
-    // sayHi will only be executed once, in the afterRender queue of the RunLoop
+    // doFoo will only be executed once, in the afterRender queue of the RunLoop
   });
   ```
 
@@ -5466,7 +5395,7 @@ Ember.run.scheduleOnce = function(queue, target, method) {
   `Ember.run.later` with a wait time of 1ms.
 
   ```javascript
-  Ember.run.next(myContext, function() {
+  Ember.run.next(myContext, function(){
     // code to be executed in the next run loop, which will be scheduled after the current one
   });
   ```
@@ -5528,17 +5457,17 @@ Ember.run.next = function() {
   `Ember.run.once()`, or `Ember.run.next()`.
 
   ```javascript
-  var runNext = Ember.run.next(myContext, function() {
+  var runNext = Ember.run.next(myContext, function(){
     // will not be executed
   });
   Ember.run.cancel(runNext);
 
-  var runLater = Ember.run.later(myContext, function() {
+  var runLater = Ember.run.later(myContext, function(){
     // will not be executed
   }, 500);
   Ember.run.cancel(runLater);
 
-  var runOnce = Ember.run.once(myContext, function() {
+  var runOnce = Ember.run.once(myContext, function(){
     // will not be executed
   });
   Ember.run.cancel(runOnce);
@@ -5553,15 +5482,8 @@ Ember.run.cancel = function(timer) {
 };
 
 /**
-  Delay calling the target method until the debounce period has elapsed
-  with no additional debounce calls. If `debounce` is called again before
-  the specified time has elapsed, the timer is reset and the entire period
-  must pass again before the target method is called.
-
-  This method should be used when an event may be called multiple times
-  but the action should only be called once when the event is done firing.
-  A common example is for scroll events where you only want updates to
-  happen once scrolling has ceased.
+  Execute the passed method in a specified amount of time, reset timer
+  upon additional calls.
 
   ```javascript
     var myFunc = function() { console.log(this.name + ' ran.'); };
@@ -5585,48 +5507,10 @@ Ember.run.cancel = function(timer) {
     then it will be looked up on the passed target.
   @param {Object} [args*] Optional arguments to pass to the timeout.
   @param {Number} wait Number of milliseconds to wait.
-  @param {Boolean} immediate Trigger the function on the leading instead of the trailing edge of the wait interval.
   @return {void}
 */
 Ember.run.debounce = function() {
   return backburner.debounce.apply(backburner, arguments);
-};
-
-/**
-  Ensure that the target method is never called more frequently than
-  the specified spacing period.
-
-  ```javascript
-    var myFunc = function() { console.log(this.name + ' ran.'); };
-    var myContext = {name: 'throttle'};
-
-    Ember.run.throttle(myContext, myFunc, 150);
-
-    // 50ms passes
-    Ember.run.throttle(myContext, myFunc, 150);
-
-    // 50ms passes
-    Ember.run.throttle(myContext, myFunc, 150);
-
-    // 50ms passes
-    Ember.run.throttle(myContext, myFunc, 150);
-
-    // 150ms passes
-    // myFunc is invoked with context myContext
-    // console logs 'throttle ran.' twice, 150ms apart.
-  ```
-
-  @method throttle
-  @param {Object} [target] target of method to invoke
-  @param {Function|String} method The method to invoke.
-    May be a function or a string. If you pass a string
-    then it will be looked up on the passed target.
-  @param {Object} [args*] Optional arguments to pass to the timeout.
-  @param {Number} spacing Number of milliseconds to space out requests.
-  @return {void}
-*/
-Ember.run.throttle = function() {
-  return backburner.throttle.apply(backburner, arguments);
 };
 
 // Make sure it's not an autorun during testing
@@ -6686,7 +6570,7 @@ Alias.prototype = new Ember.Descriptor();
   App.PaintSample = Ember.Object.extend({
     color: 'red',
     colour: Ember.alias('color'),
-    name: function() {
+    name: function(){
       return "Zed";
     },
     moniker: Ember.alias("name")
@@ -6714,7 +6598,7 @@ Ember.alias = Ember.deprecateFunc("Ember.alias is deprecated. Please use Ember.a
 
   ```javascript
   App.Person = Ember.Object.extend({
-    name: function() {
+    name: function(){
       return 'Tomhuda Katzdale';
     },
     moniker: Ember.aliasMethod('name')
@@ -6783,7 +6667,7 @@ Ember.immediateObserver = function() {
     }.observesBefore('content.value'),
     valueDidChange: function(obj, keyName, value) {
         // only run if updating a value already in the DOM
-        if (this.get('state') === 'inDOM') {
+        if(this.get('state') === 'inDOM') {
             var color = value > this.changingFrom ? 'green' : 'red';
             // logic
         }
@@ -6894,7 +6778,7 @@ define("rsvp/async",
       observer.observe(element, { attributes: true });
 
       // Chrome Memory Leak: https://bugs.webkit.org/show_bug.cgi?id=93661
-      window.addEventListener('unload', function() {
+      window.addEventListener('unload', function(){
         observer.disconnect();
         observer = null;
       });
@@ -7160,7 +7044,7 @@ define("rsvp/promise",
       return isFunction(x) || (typeof x === "object" && x !== null);
     }
 
-    function isFunction(x) {
+    function isFunction(x){
       return typeof x === "function";
     }
 
@@ -7358,12 +7242,12 @@ define("rsvp/resolve",
       return typeof x === "function" || (typeof x === "object" && x !== null);
     }
 
-    function resolve(thenable) {
-      var promise = new Promise(function(resolve, reject) {
+    function resolve(thenable){
+      var promise = new Promise(function(resolve, reject){
         var then;
 
         try {
-          if (objectOrFunction(thenable)) {
+          if ( objectOrFunction(thenable) ) {
             then = thenable.then;
 
             if (typeof then === "function") {
@@ -7427,43 +7311,12 @@ define("container",
   [],
   function() {
 
-   /**
-     A safe and simple inheriting object.
-
-     @class InheritingDict
-   */
     function InheritingDict(parent) {
       this.parent = parent;
       this.dict = {};
     }
 
     InheritingDict.prototype = {
-
-      /**
-        @property parent
-        @type InheritingDict
-        @default null
-      */
-
-      parent: null,
-
-      /**
-        Object used to store the current nodes data.
-
-        @property dict
-        @type Object
-        @default Object
-      */
-      dict: null,
-
-      /**
-        Retrieve the value given a key, if the value is present at the current
-        level use it, otherwise walk up the parent hierarchy and try again. If
-        no matching key is found, return undefined.
-
-        @method get
-        @return {any}
-      */
       get: function(key) {
         var dict = this.dict;
 
@@ -7476,36 +7329,10 @@ define("container",
         }
       },
 
-      /**
-        Set the given value for the given key, at the current level.
-
-        @method set
-        @param {String} key
-        @param {Any} value
-      */
       set: function(key, value) {
         this.dict[key] = value;
       },
 
-      /**
-        Delete the given key
-
-        @method remove
-        @param {String} key
-      */
-      remove: function(key) {
-        delete this.dict[key];
-      },
-
-      /**
-        Check for the existence of given a key, if the key is present at the current
-        level return true, otherwise walk up the parent hierarchy and try again. If
-        no matching key is found, return false.
-
-        @method has
-        @param {String} key
-        @returns {Boolean}
-      */
       has: function(key) {
         var dict = this.dict;
 
@@ -7520,13 +7347,6 @@ define("container",
         return false;
       },
 
-      /**
-        Iterate and invoke a callback for each local key-value pair.
-
-        @method eachLocal
-        @param {Function} callback
-        @param {Object} binding
-      */
       eachLocal: function(callback, binding) {
         var dict = this.dict;
 
@@ -7538,11 +7358,6 @@ define("container",
       }
     };
 
-   /**
-     A lightweight container that helps to assemble and decouple components.
-
-     @class Container
-   */
     function Container(parent) {
       this.parent = parent;
       this.children = [];
@@ -7557,119 +7372,20 @@ define("container",
     }
 
     Container.prototype = {
-
-      /**
-        @property parent
-        @type Container
-        @default null
-      */
-      parent: null,
-
-      /**
-        @property children
-        @type Array
-        @default []
-      */
-      children: null,
-
-      /**
-        @property resolver
-        @type function
-      */
-      resolver: null,
-
-      /**
-        @property registry
-        @type InheritingDict
-      */
-      registry: null,
-
-      /**
-        @property cache
-        @type InheritingDict
-      */
-      cache: null,
-
-      /**
-        @property typeInjections
-        @type InheritingDict
-      */
-      typeInjections: null,
-
-      /**
-        @property injections
-        @type Object
-        @default {}
-      */
-      injections: null,
-
-      /**
-        @private
-
-        @property _options
-        @type InheritingDict
-        @default null
-      */
-      _options: null,
-
-      /**
-        @private
-
-        @property _typeOptions
-        @type InheritingDict
-      */
-      _typeOptions: null,
-
-      /**
-        Returns a new child of the current container. These children are configured
-        to correctly inherit from the current container.
-
-        @method child
-        @returns {Container}
-      */
       child: function() {
         var container = new Container(this);
         this.children.push(container);
         return container;
       },
 
-      /**
-        Sets a key-value pair on the current container. If a parent container,
-        has the same key, once set on a child, the parent and child will diverge
-        as expected.
-
-        @method set
-        @param {Object} obkect
-        @param {String} key
-        @param {any} value
-      */
       set: function(object, key, value) {
         object[key] = value;
       },
 
-      /**
-        Registers a factory for later injection.
-
-        Example:
-
-        ```javascript
-        var container = new Container();
-
-        container.register('model:user', Person, {singleton: false });
-        container.register('fruit:favorite', Orange);
-        container.register('communication:main', Email, {singleton: false});
-        ```
-
-        @method register
-        @param {String} type
-        @param {String} name
-        @param {Function} factory
-        @param {Object} options
-      */
       register: function(type, name, factory, options) {
         var fullName;
 
-        if (type.indexOf(':') !== -1) {
+        if (type.indexOf(':') !== -1){
           options = factory;
           factory = name;
           fullName = type;
@@ -7684,115 +7400,14 @@ define("container",
         this._options.set(normalizedName, options || {});
       },
 
-      /**
-        Unregister a fullName
-
-        ```javascript
-        var container = new Container();
-        container.register('model:user', User);
-
-        container.lookup('model:user') instanceof User //=> true
-
-        container.unregister('model:user')
-        container.lookup('model:user') === undefined //=> true
-
-        @method unregister
-        @param {String} fullName
-       */
-      unregister: function(fullName) {
-        var normalizedName = this.normalize(fullName);
-
-        this.registry.remove(normalizedName);
-        this.cache.remove(normalizedName);
-        this._options.remove(normalizedName);
-      },
-
-      /**
-        Given a fullName return the corresponding factory.
-
-        By default `resolve` will retrieve the factory from
-        its container's registry.
-
-        ```javascript
-        var container = new Container();
-        container.register('api:twitter', Twitter);
-
-        container.resolve('api:twitter') // => Twitter
-        ```
-
-        Optionally the container can be provided with a custom resolver.
-        If provided, `resolve` will first provide the custom resolver
-        the oppertunity to resolve the fullName, otherwise it will fallback
-        to the registry.
-
-        ```javascript
-        var container = new Container();
-        container.resolver = function(fullName) {
-          // lookup via the module system of choice
-        };
-
-        // the twitter factory is added to the module system
-        container.resolve('api:twitter') // => Twitter
-        ```
-
-        @method resolve
-        @param {String} fullName
-        @returns {Function} fullName's factory
-      */
       resolve: function(fullName) {
         return this.resolver(fullName) || this.registry.get(fullName);
       },
 
-      /**
-        A hook to enable custom fullName normalization behaviour
-
-        @method normalize
-        @param {String} fullName
-        @return {string} normalized fullName
-      */
       normalize: function(fullName) {
         return fullName;
       },
 
-      /**
-        Given a fullName return a corresponding instance.
-
-        The default behaviour is for lookup to return a singleton instance.
-        The singleton is scoped to the container, allowing multiple containers
-        to all have there own locally scoped singletons.
-
-        ```javascript
-        var container = new Container();
-        container.register('api:twitter', Twitter);
-
-        var twitter = container.lookup('api:twitter');
-
-        twitter instanceof Twitter; // => true
-
-        // by default the container will return singletons
-        twitter2 = container.lookup('api:twitter');
-        twitter instanceof Twitter; // => true
-
-        twitter === twitter2; //=> true
-        ```
-
-        If singletons are not wanted an optional flag can be provided at lookup.
-
-        ```javascript
-        var container = new Container();
-        container.register('api:twitter', Twitter);
-
-        var twitter = container.lookup('api:twitter', { singleton: false });
-        var twitter2 = container.lookup('api:twitter', { singleton: false });
-
-        twitter === twitter2; //=> false
-        ```
-
-        @method lookup
-        @param {String} fullName
-        @param {Object} options
-        @return {any}
-      */
       lookup: function(fullName, options) {
         fullName = this.normalize(fullName);
 
@@ -7813,25 +7428,10 @@ define("container",
         return value;
       },
 
-      /**
-        Given a fullName return the corresponding factory.
-
-        @method lookupFactory
-        @param {String} fullName
-        @return {any}
-      */
       lookupFactory: function(fullName) {
         return factoryFor(this, fullName);
       },
 
-      /**
-        Given a fullName check if the container is aware of its factory
-        or singleton instance.
-
-        @method has
-        @param {String} fullName
-        @return {Boolean}
-      */
       has: function(fullName) {
         if (this.cache.has(fullName)) {
           return true;
@@ -7840,144 +7440,27 @@ define("container",
         return !!factoryFor(this, fullName);
       },
 
-      /**
-        Allow registerying options for all factories of a type.
-
-        ```javascript
-        var container = new Container();
-
-        // if all of type `connection` must not be singletons
-        container.optionsForType('connection', { singleton: false });
-
-        container.register('connection:twitter', TwitterConnection);
-        container.register('connection:facebook', FacebookConnection);
-
-        var twitter = container.lookup('connection:twitter');
-        var twitter2 = container.lookup('connection:twitter');
-
-        twitter === twitter2; // => false
-
-        var facebook = container.lookup('connection:facebook');
-        var facebook2 = container.lookup('connection:facebook');
-
-        facebook === facebook2; // => false
-        ```
-
-        @method optionsForType
-        @param {String} type
-        @param {Object} options
-      */
       optionsForType: function(type, options) {
         if (this.parent) { illegalChildOperation('optionsForType'); }
 
         this._typeOptions.set(type, options);
       },
 
-      /**
-        @method options
-        @param {String} type
-        @param {Object} options
-      */
       options: function(type, options) {
         this.optionsForType(type, options);
       },
 
-      /*
-        @private
-
-        Used only via `injection`.
-
-        Provides a specialized form of injection, specifically enabling
-        all objects of one type to be injected with a reference to another
-        object.
-
-        For example, provided each object of type `controller` needed a `router`.
-        one would do the following:
-
-        ```javascript
-        var container = new Container();
-
-        container.register('router:main', Router);
-        container.register('controller:user', UserController);
-        container.register('controller:post', PostController);
-
-        container.typeInjection('controller', 'router', 'router:main');
-
-        var user = container.lookup('controller:user');
-        var post = container.lookup('controller:post');
-
-        user.router instanceof Router; //=> true
-        post.router instanceof Router; //=> true
-
-        // both controllers share the same router
-        user.router === post.router; //=> true
-        ```
-
-        @method typeInjection
-        @param {String} type
-        @param {String} property
-        @param {String} fullName
-      */
       typeInjection: function(type, property, fullName) {
         if (this.parent) { illegalChildOperation('typeInjection'); }
 
         var injections = this.typeInjections.get(type);
-
         if (!injections) {
           injections = [];
           this.typeInjections.set(type, injections);
         }
-
-        injections.push({
-          property: property,
-          fullName: fullName
-        });
+        injections.push({ property: property, fullName: fullName });
       },
 
-      /*
-        Defines injection rules.
-
-        These rules are used to inject dependencies onto objects when they
-        are instantiated.
-
-        Two forms of injections are possible:
-
-        * Injecting one fullName on another fullName
-        * Injecting one fullName on a type
-
-        Example:
-
-        ```javascript
-        var container = new Container();
-
-        container.register('source:main', Source);
-        container.register('model:user', User);
-        container.register('model:post', PostController);
-
-        // injecting one fullName on another fullName
-        // eg. each user model gets a post model
-        container.injection('model:user', 'post', 'model:post');
-
-        // injecting one fullName on another type
-        container.injection('model', 'source', 'source:main');
-
-        var user = container.lookup('model:user');
-        var post = container.lookup('model:post');
-
-        user.source instanceof Source; //=> true
-        post.source instanceof Source; //=> true
-
-        user.post instanceof Post; //=> true
-
-        // and both models share the same source
-        user.source === post.source; //=> true
-        ```
-
-        @method injection
-        @param {String} factoryName
-        @param {String} property
-        @param {String} injectionName
-      */
       injection: function(factoryName, property, injectionName) {
         if (this.parent) { illegalChildOperation('injection'); }
 
@@ -7989,12 +7472,6 @@ define("container",
         injections.push({ property: property, fullName: injectionName });
       },
 
-      /**
-        A depth first traversal, destroying the container, its descendant containers and all
-        their managed objects.
-
-        @method destroy
-      */
       destroy: function() {
         this.isDestroyed = true;
 
@@ -8012,9 +7489,6 @@ define("container",
         this.isDestroyed = true;
       },
 
-      /**
-        @method reset
-      */
       reset: function() {
         for (var i=0, l=this.children.length; i<l; i++) {
           resetCache(this.children[i]);
@@ -8043,12 +7517,7 @@ define("container",
       for (var i=0, l=injections.length; i<l; i++) {
         injection = injections[i];
         lookup = container.lookup(injection.fullName);
-
-        if (lookup) {
-          hash[injection.property] = lookup;
-        } else {
-          throw new Error('Attempting to inject an unknown injection: `' + injection.fullName + '`');
-        }
+        hash[injection.property] = lookup;
       }
 
       return hash;
@@ -8317,11 +7786,7 @@ Ember.copy = function(obj, deep) {
   @return {String} A description of the object
 */
 Ember.inspect = function(obj) {
-  var type = Ember.typeOf(obj);
-  if (type === 'array') {
-    return '[' + obj + ']';
-  }
-  if (type !== 'object') {
+  if (typeof obj !== 'object' || obj === null) {
     return obj + '';
   }
 
@@ -8504,9 +7969,9 @@ Ember.String = {
     // first, replace any ORDERED replacements.
     var idx  = 0; // the current index for non-numerical replacements
     return str.replace(/%@([0-9]+)?/g, function(s, argIndex) {
-      argIndex = (argIndex) ? parseInt(argIndex, 10) - 1 : idx++;
+      argIndex = (argIndex) ? parseInt(argIndex,0) - 1 : idx++ ;
       s = formats[argIndex];
-      return (s === null) ? '(null)' : (s === undefined) ? '' : Ember.inspect(s);
+      return ((s === null) ? '(null)' : (s === undefined) ? '' : s).toString();
     }) ;
   },
 
@@ -9029,6 +8494,9 @@ function iter(key, value) {
 */
 Ember.Enumerable = Ember.Mixin.create({
 
+  // compatibility
+  isEnumerable: true,
+
   /**
     Implement this method to make your class enumerable.
 
@@ -9238,7 +8706,7 @@ Ember.Enumerable = Ember.Mixin.create({
     @return {Array} The mapped array.
   */
   map: function(callback, target) {
-    var ret = Ember.A();
+    var ret = Ember.A([]);
     this.forEach(function(x, idx, i) {
       ret[idx] = callback.call(target, x, idx,i);
     });
@@ -9288,7 +8756,7 @@ Ember.Enumerable = Ember.Mixin.create({
     @return {Array} A filtered array.
   */
   filter: function(callback, target) {
-    var ret = Ember.A();
+    var ret = Ember.A([]);
     this.forEach(function(x, idx, i) {
       if (callback.call(target, x, idx, i)) ret.push(x);
     });
@@ -9577,7 +9045,7 @@ Ember.Enumerable = Ember.Mixin.create({
     @return {Array} return values from calling invoke.
   */
   invoke: function(methodName) {
-    var args, ret = Ember.A();
+    var args, ret = Ember.A([]);
     if (arguments.length>1) args = a_slice.call(arguments, 1);
 
     this.forEach(function(x, idx) {
@@ -9598,7 +9066,7 @@ Ember.Enumerable = Ember.Mixin.create({
     @return {Array} the enumerable as an array.
   */
   toArray: function() {
-    var ret = Ember.A();
+    var ret = Ember.A([]);
     this.forEach(function(o, idx) { ret[idx] = o; });
     return ret ;
   },
@@ -9634,7 +9102,7 @@ Ember.Enumerable = Ember.Mixin.create({
   */
   without: function(value) {
     if (!this.contains(value)) return this; // nothing to do
-    var ret = Ember.A();
+    var ret = Ember.A([]);
     this.forEach(function(k) {
       if (k !== value) ret[ret.length] = k;
     }) ;
@@ -9654,8 +9122,8 @@ Ember.Enumerable = Ember.Mixin.create({
     @return {Ember.Enumerable}
   */
   uniq: function() {
-    var ret = Ember.A();
-    this.forEach(function(k) {
+    var ret = Ember.A([]);
+    this.forEach(function(k){
       if (a_indexOf(ret, k)<0) ret.push(k);
     });
     return ret;
@@ -9915,7 +9383,7 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
    */
   objectsAt: function(indexes) {
     var self = this;
-    return map(indexes, function(idx) { return self.objectAt(idx); });
+    return map(indexes, function(idx){ return self.objectAt(idx); });
   },
 
   // overrides Ember.Enumerable version
@@ -9947,7 +9415,7 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
   }),
 
   // optimized version from Enumerable
-  contains: function(obj) {
+  contains: function(obj){
     return this.indexOf(obj) >= 0;
   },
 
@@ -9970,7 +9438,7 @@ Ember.Array = Ember.Mixin.create(Ember.Enumerable, /** @scope Ember.Array.protot
     @return {Array} New array with specified slice
   */
   slice: function(beginIndex, endIndex) {
-    var ret = Ember.A();
+    var ret = Ember.A([]);
     var length = get(this, 'length') ;
     if (isNone(beginIndex)) beginIndex = 0 ;
     if (isNone(endIndex) || (endIndex > length)) endIndex = length ;
@@ -10727,7 +10195,7 @@ Ember.MutableArray = Ember.Mixin.create(Ember.Array, Ember.MutableEnumerable,/**
 
     ```javascript
     var colors = ["red", "green", "blue"];
-    colors.pushObjects(["black"]);               // ["red", "green", "blue", "black"]
+    colors.pushObjects("black");               // ["red", "green", "blue", "black"]
     colors.pushObjects(["yellow", "orange"]);  // ["red", "green", "blue", "black", "yellow", "orange"]
     ```
 
@@ -10736,9 +10204,6 @@ Ember.MutableArray = Ember.Mixin.create(Ember.Array, Ember.MutableEnumerable,/**
     @return {Ember.Array} receiver
   */
   pushObjects: function(objects) {
-    if (!(Ember.Enumerable.detect(objects) || Ember.isArray(objects))) {
-      throw new TypeError("Must pass Ember.Enumerable to Ember.MutableArray#pushObjects");
-    }
     this.replace(get(this, 'length'), 0, objects);
     return this;
   },
@@ -11157,7 +10622,7 @@ Ember.Observable = Ember.Mixin.create(/** @scope Ember.Observable.prototype */ {
     @param {String} keyName The property key that is about to change.
     @return {Ember.Observable}
   */
-  propertyWillChange: function(keyName) {
+  propertyWillChange: function(keyName){
     Ember.propertyWillChange(this, keyName);
     return this;
   },
@@ -11463,7 +10928,7 @@ Ember.TargetActionSupport = Ember.Mixin.create({
     target: Ember.computed.alias('controller'),
     action: 'save',
     actionContext: Ember.computed.alias('context'),
-    click: function() {
+    click: function(){
       this.triggerAction(); // Sends the `save` action, along with the current context
                             // to the current controller
     }
@@ -11475,7 +10940,7 @@ Ember.TargetActionSupport = Ember.Mixin.create({
 
   ```javascript
   App.SaveButtonView = Ember.View.extend(Ember.TargetActionSupport, {
-    click: function() {
+    click: function(){
       this.triggerAction({
         action: 'save',
         target: this.get('controller'),
@@ -11493,7 +10958,7 @@ Ember.TargetActionSupport = Ember.Mixin.create({
   ```javascript
   App.SaveButtonView = Ember.View.extend(Ember.TargetActionSupport, {
     target: Ember.computed.alias('controller'),
-    click: function() {
+    click: function(){
       this.triggerAction({
         action: 'save'
       }); // Sends the `save` action, along with a reference to `this`,
@@ -11661,7 +11126,7 @@ Ember.Evented = Ember.Mixin.create({
   },
 
   /**
-    Cancels subscription for given name, target, and method.
+    Cancels subscription for give name, target, and method.
 
     @method off
     @param {String} name The name of the event
@@ -11746,7 +11211,7 @@ Ember.DeferredMixin = Ember.Mixin.create({
     deferred = get(this, '_deferred');
     promise = deferred.promise;
 
-    if (value === this) {
+    if (value === this){
       deferred.resolve(promise);
     } else {
       deferred.resolve(value);
@@ -11793,8 +11258,8 @@ Ember.Container.set = Ember.set;
 */
 
 
-// NOTE: this object should never be included directly. Instead use `Ember.Object`.
-// We only define this separately so that `Ember.Set` can depend on it.
+// NOTE: this object should never be included directly. Instead use Ember.
+// Ember.Object. We only define this separately so that Ember.Set can depend on it
 
 
 var set = Ember.set, get = Ember.get,
@@ -12135,7 +11600,7 @@ CoreObject.PrototypeMixin = Mixin.create({
     included in the output.
 
         App.Teacher = App.Person.extend({
-          toStringExtension: function() {
+          toStringExtension: function(){
             return this.get('fullName');
           }
         });
@@ -12826,9 +12291,6 @@ Ember.ArrayProxy = Ember.Object.extend(Ember.MutableArray,/** @scope Ember.Array
   },
 
   pushObjects: function(objects) {
-    if (!(Ember.Enumerable.detect(objects) || Ember.isArray(objects))) {
-      throw new TypeError("Must pass Ember.Enumerable to Ember.MutableArray#pushObjects");
-    }
     this._replace(get(this, 'length'), 0, objects);
     return this;
   },
@@ -13337,7 +12799,7 @@ var NativeArray = Ember.Mixin.create(Ember.MutableArray, Ember.Observable, Ember
 
   copy: function(deep) {
     if (deep) {
-      return this.map(function(item) { return Ember.copy(item, true); });
+      return this.map(function(item){ return Ember.copy(item, true); });
     }
 
     return this.slice();
@@ -13378,7 +12840,7 @@ Ember.NativeArray = NativeArray;
   @for Ember
   @return {Ember.NativeArray}
 */
-Ember.A = function(arr) {
+Ember.A = function(arr){
   if (arr === undefined) { arr = []; }
   return Ember.Array.detect(arr) ? arr : Ember.NativeArray.apply(arr);
 };
@@ -13554,7 +13016,7 @@ Ember.Set = Ember.CoreObject.extend(Ember.MutableEnumerable, Ember.Copyable, Emb
     Ember.propertyWillChange(this, 'firstObject');
     Ember.propertyWillChange(this, 'lastObject');
 
-    for (var i=0; i < len; i++) {
+    for (var i=0; i < len; i++){
       guid = guidFor(this[i]);
       delete this[guid];
       delete this[i];
@@ -14008,7 +13470,7 @@ Ember.ControllerMixin = Ember.Mixin.create({
     if (this[actionName]) {
       Ember.assert("The controller " + this + " does not have the action " + actionName, typeof this[actionName] === 'function');
       this[actionName].apply(this, args);
-    } else if (target = get(this, 'target')) {
+    } else if(target = get(this, 'target')) {
       Ember.assert("The target for controller " + this + " (" + target + ") did not define a `send` method", typeof target.send === 'function');
       target.send.apply(target, arguments);
     }
@@ -14090,8 +13552,8 @@ Ember.SortableMixin = Ember.Mixin.create(Ember.MutableEnumerable, {
       return a positive value otherwise:
 
     ```javascript
-    function(x,y) { // These are assumed to be integers
-      if (x === y)
+    function(x,y){ // These are assumed to be integers
+      if(x === y)
         return 0;
       return x < y ? -1 : 1;
     }
@@ -14597,7 +14059,7 @@ if (Ember.$) {
 // is a "zero-scope" element. This problem can be worked around by making
 // the first node an invisible text node. We, like Modernizr, use &shy;
 
-var needsShy = this.document && (function() {
+var needsShy = this.document && (function(){
   var testEl = document.createElement('div');
   testEl.innerHTML = "<div></div>";
   testEl.firstChild.innerHTML = "<script></script>";
@@ -14752,6 +14214,45 @@ ClassSet.prototype = {
     return this.list.join(" ");
   }
 };
+
+var BAD_TAG_NAME_TEST_REGEXP = /[^a-zA-Z\-]/;
+var BAD_TAG_NAME_REPLACE_REGEXP = /[^a-zA-Z\-]/g;
+
+function stripTagName(tagName) {
+  if (!tagName) {
+    return tagName;
+  }
+
+  if (!BAD_TAG_NAME_TEST_REGEXP.test(tagName)) {
+    return tagName;
+  }
+
+  return tagName.replace(BAD_TAG_NAME_REPLACE_REGEXP, '');
+}
+
+var BAD_CHARS_REGEXP = /&(?!\w+;)|[<>"'`]/g;
+var POSSIBLE_CHARS_REGEXP = /[&<>"'`]/;
+
+function escapeAttribute(value) {
+  // Stolen shamelessly from Handlebars
+
+  var escape = {
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+    "'": "&#x27;",
+    "`": "&#x60;"
+  };
+
+  var escapeChar = function(chr) {
+    return escape[chr] || "&amp;";
+  };
+
+  var string = value.toString();
+
+  if(!POSSIBLE_CHARS_REGEXP.test(string)) { return string; }
+  return string.replace(BAD_CHARS_REGEXP, escapeChar);
+}
 
 /**
   `Ember.RenderBuffer` gathers information regarding the a view and generates the
@@ -15040,14 +14541,14 @@ Ember._RenderBuffer.prototype =
         style = this.elementStyle,
         attr, prop;
 
-    buffer += '<' + tagName;
+    buffer += '<' + stripTagName(tagName);
 
     if (id) {
-      buffer += ' id="' + this._escapeAttribute(id) + '"';
+      buffer += ' id="' + escapeAttribute(id) + '"';
       this.elementId = null;
     }
     if (classes) {
-      buffer += ' class="' + this._escapeAttribute(classes.join(' ')) + '"';
+      buffer += ' class="' + escapeAttribute(classes.join(' ')) + '"';
       this.classes = null;
     }
 
@@ -15056,7 +14557,7 @@ Ember._RenderBuffer.prototype =
 
       for (prop in style) {
         if (style.hasOwnProperty(prop)) {
-          buffer += prop + ':' + this._escapeAttribute(style[prop]) + ';';
+          buffer += prop + ':' + escapeAttribute(style[prop]) + ';';
         }
       }
 
@@ -15068,7 +14569,7 @@ Ember._RenderBuffer.prototype =
     if (attrs) {
       for (attr in attrs) {
         if (attrs.hasOwnProperty(attr)) {
-          buffer += ' ' + attr + '="' + this._escapeAttribute(attrs[attr]) + '"';
+          buffer += ' ' + attr + '="' + escapeAttribute(attrs[attr]) + '"';
         }
       }
 
@@ -15083,7 +14584,7 @@ Ember._RenderBuffer.prototype =
             if (value === true) {
               buffer += ' ' + prop + '="' + prop + '"';
             } else {
-              buffer += ' ' + prop + '="' + this._escapeAttribute(props[prop]) + '"';
+              buffer += ' ' + prop + '="' + escapeAttribute(props[prop]) + '"';
             }
           }
         }
@@ -15098,7 +14599,7 @@ Ember._RenderBuffer.prototype =
 
   pushClosingTag: function() {
     var tagName = this.tagNames.pop();
-    if (tagName) { this.buffer += '</' + tagName + '>'; }
+    if (tagName) { this.buffer += '</' + stripTagName(tagName) + '>'; }
   },
 
   currentTagName: function() {
@@ -15185,7 +14686,7 @@ Ember._RenderBuffer.prototype =
     if (this._hasElement && this._element) {
       // Firefox versions < 11 do not have support for element.outerHTML.
       var thisElement = this.element(), outerHTML = thisElement.outerHTML;
-      if (typeof outerHTML === 'undefined') {
+      if (typeof outerHTML === 'undefined'){
         return Ember.$('<div/>').append(thisElement).html();
       }
       return outerHTML;
@@ -15196,32 +14697,7 @@ Ember._RenderBuffer.prototype =
 
   innerString: function() {
     return this.buffer;
-  },
-
-  _escapeAttribute: function(value) {
-    // Stolen shamelessly from Handlebars
-
-    var escape = {
-      "<": "&lt;",
-      ">": "&gt;",
-      '"': "&quot;",
-      "'": "&#x27;",
-      "`": "&#x60;"
-    };
-
-    var badChars = /&(?!\w+;)|[<>"'`]/g;
-    var possible = /[&<>"'`]/;
-
-    var escapeChar = function(chr) {
-      return escape[chr] || "&amp;";
-    };
-
-    var string = value.toString();
-
-    if (!possible.test(string)) { return string; }
-    return string.replace(badChars, escapeChar);
   }
-
 };
 
 })();
@@ -15537,11 +15013,8 @@ var childViewsProperty = Ember.computed(function() {
   var childViews = this._childViews, ret = Ember.A(), view = this;
 
   a_forEach(childViews, function(view) {
-    var currentChildViews;
     if (view.isVirtual) {
-      if (currentChildViews = get(view, 'childViews')) {
-        ret.pushObjects(currentChildViews);
-      }
+      ret.pushObjects(get(view, 'childViews'));
     } else {
       ret.push(view);
     }
@@ -15836,8 +15309,8 @@ class:
   MyView = Ember.View.extend({
     classNameBindings: ['propertyA', 'propertyB'],
     propertyA: 'from-a',
-    propertyB: function() {
-      if (someLogic) { return 'from-b'; }
+    propertyB: function(){
+      if(someLogic){ return 'from-b'; }
     }.property()
   });
   ```
@@ -16018,7 +15491,7 @@ class:
   MyTextInput = Ember.View.extend({
     tagName: 'input',
     attributeBindings: ['disabled'],
-    disabled: function() {
+    disabled: function(){
       if (someLogic) {
         return true;
       } else {
@@ -16127,7 +15600,7 @@ class:
 
   aController = Ember.Object.create({
     firstName: 'Barry',
-    excitedGreeting: function() {
+    excitedGreeting: function(){
       return this.get("content.firstName") + "!!!"
     }.property()
   });
@@ -16198,7 +15671,7 @@ class:
 
   ```javascript
   AView = Ember.View.extend({
-    click: function(event) {
+    click: function(event){
       // will be called when when an instance's
       // rendered element is clicked
     }
@@ -16219,7 +15692,7 @@ class:
   ```javascript
   AView = Ember.View.extend({
     eventManager: Ember.Object.create({
-      doubleClick: function(event, view) {
+      doubleClick: function(event, view){
         // will be called when when an instance's
         // rendered element or any rendering
         // of this views's descendent
@@ -16234,11 +15707,11 @@ class:
 
   ```javascript
   AView = Ember.View.extend({
-    mouseEnter: function(event) {
+    mouseEnter: function(event){
       // will never trigger.
     },
     eventManager: Ember.Object.create({
-      mouseEnter: function(event, view) {
+      mouseEnter: function(event, view){
         // takes presedence over AView#mouseEnter
       }
     })
@@ -16256,7 +15729,7 @@ class:
   OuterView = Ember.View.extend({
     template: Ember.Handlebars.compile("outer {{#view InnerView}}inner{{/view}} outer"),
     eventManager: Ember.Object.create({
-      mouseEnter: function(event, view) {
+      mouseEnter: function(event, view){
         // view might be instance of either
         // OuterView or InnerView depending on
         // where on the page the user interaction occured
@@ -16265,12 +15738,12 @@ class:
   });
 
   InnerView = Ember.View.extend({
-    click: function(event) {
+    click: function(event){
       // will be called if rendered inside
       // an OuterView because OuterView's
       // eventManager doesn't handle click events
     },
-    mouseEnter: function(event) {
+    mouseEnter: function(event){
       // will never be called if rendered inside
       // an OuterView.
     }
@@ -16581,7 +16054,7 @@ Ember.View = Ember.CoreView.extend(
     var view = get(this, 'parentView');
 
     while (view) {
-      if (view instanceof klass) { return view; }
+      if(view instanceof klass) { return view; }
       view = get(view, 'parentView');
     }
   },
@@ -16602,7 +16075,7 @@ Ember.View = Ember.CoreView.extend(
                    function(view) { return klass.detect(view.constructor); };
 
     while (view) {
-      if (isOfType(view)) { return view; }
+      if( isOfType(view) ) { return view; }
       view = get(view, 'parentView');
     }
   },
@@ -16635,7 +16108,7 @@ Ember.View = Ember.CoreView.extend(
     var view = get(this, 'parentView');
 
     while (view) {
-      if (get(view, 'parentView') instanceof klass) { return view; }
+      if(get(view, 'parentView') instanceof klass) { return view; }
       view = get(view, 'parentView');
     }
   },
@@ -17158,7 +16631,7 @@ Ember.View = Ember.CoreView.extend(
   */
   invokeRecursively: function(fn, includeSelf) {
     var childViews = (includeSelf === false) ? this._childViews : [this];
-    var currentViews, view, currentChildViews;
+    var currentViews, view;
 
     while (childViews.length) {
       currentViews = childViews.slice();
@@ -17166,17 +16639,16 @@ Ember.View = Ember.CoreView.extend(
 
       for (var i=0, l=currentViews.length; i<l; i++) {
         view = currentViews[i];
-        currentChildViews = view._childViews ? view._childViews.slice(0) : null;
         fn(view);
-        if (currentChildViews) {
-          childViews.push.apply(childViews, currentChildViews);
+        if (view._childViews) {
+          childViews.push.apply(childViews, view._childViews);
         }
       }
     }
   },
 
   triggerRecursively: function(eventName) {
-    var childViews = [this], currentViews, view, currentChildViews;
+    var childViews = [this], currentViews, view;
 
     while (childViews.length) {
       currentViews = childViews.slice();
@@ -17184,12 +16656,10 @@ Ember.View = Ember.CoreView.extend(
 
       for (var i=0, l=currentViews.length; i<l; i++) {
         view = currentViews[i];
-        currentChildViews = view._childViews ? view._childViews.slice(0) : null;
         if (view.trigger) { view.trigger(eventName); }
-        if (currentChildViews) {
-          childViews.push.apply(childViews, currentChildViews);
+        if (view._childViews) {
+          childViews.push.apply(childViews, view._childViews);
         }
-
       }
     }
   },
@@ -17236,7 +16706,7 @@ Ember.View = Ember.CoreView.extend(
 
     @event willDestroyElement
   */
-  willDestroyElement: Ember.K,
+  willDestroyElement: function() {},
 
   /**
     @private
@@ -17748,7 +17218,7 @@ Ember.View = Ember.CoreView.extend(
     }
 
     var view = this,
-        stateCheckedObserver = function() {
+        stateCheckedObserver = function(){
           view.currentState.invokeObserver(this, observer);
         },
         scheduledObserver = function() {
@@ -17982,7 +17452,7 @@ Ember.View.applyAttributeBindings = function(elem, name, value) {
     }
   } else if (name === 'value' || type === 'boolean') {
     // We can't set properties to undefined or null
-    if (Ember.isNone(value)) { value = ''; }
+    if (!value) { value = ''; }
 
     if (value !== elem.prop(name)) {
       // value and booleans should always be properties
@@ -19164,9 +18634,9 @@ Ember.CollectionView.CONTAINER_MAP = {
 
   The easiest way to create an `Ember.Component` is via
   a template. If you name a template
-  `components/my-foo`, you will be able to use
+  `controls/my-foo`, you will be able to use
   `{{my-foo}}` in other templates, which will make
-  an instance of the isolated component.
+  an instance of the isolated control.
 
   ```html
   {{app-profile person=currentUser}}
@@ -19183,24 +18653,25 @@ Ember.CollectionView.CONTAINER_MAP = {
   include the **contents** of the custom tag:
 
   ```html
-  {{#app-profile person=currentUser}}
-    <p>Admin mode</p>
-  {{/app-profile}}
+  {{#my-profile person=currentUser}}
+  <p>Admin mode</p>
+  {{/my-profile}}
   ```
 
   ```html
   <!-- app-profile template -->
+
   <h1>{{person.title}}</h1>
   {{yield}} <!-- block contents -->
   ```
 
-  If you want to customize the component, in order to
+  If you want to customize the control, in order to
   handle events or actions, you implement a subclass
   of `Ember.Component` named after the name of the
-  component.
+  control.
 
   For example, you could implement the action
-  `hello` for the `app-profile` component:
+  `hello` for the `app-profile` control:
 
   ```js
   App.AppProfileComponent = Ember.Component.extend({
@@ -19210,7 +18681,7 @@ Ember.CollectionView.CONTAINER_MAP = {
   });
   ```
 
-  And then use it in the component's template:
+  And then use it in the control's template:
 
   ```html
   <!-- app-profile template -->
@@ -19267,7 +18738,7 @@ For example:
 ```javascript
 App.SaveButtonView = Ember.View.extend(Ember.ViewTargetActionSupport, {
   action: 'save',
-  click: function() {
+  click: function(){
     this.triggerAction(); // Sends the `save` action, along with the current context
                           // to the current controller
   }
@@ -19279,7 +18750,7 @@ to `triggerAction` as well.
 
 ```javascript
 App.SaveButtonView = Ember.View.extend(Ember.ViewTargetActionSupport, {
-  click: function() {
+  click: function(){
     this.triggerAction({
       action: 'save'
     }); // Sends the `save` action, along with the current context
@@ -19335,7 +18806,7 @@ define("metamorph",
     // Copyright: ©2011 My Company Inc. All rights reserved.
     // ==========================================================================
 
-    var K = function() {},
+    var K = function(){},
         guid = 0,
         document = this.document,
 
@@ -19345,7 +18816,7 @@ define("metamorph",
         // Internet Explorer prior to 9 does not allow setting innerHTML if the first element
         // is a "zero-scope" element. This problem can be worked around by making
         // the first node an invisible text node. We, like Modernizr, use &shy;
-        needsShy = document && (function() {
+        needsShy = document && (function(){
           var testEl = document.createElement('div');
           testEl.innerHTML = "<div></div>";
           testEl.firstChild.innerHTML = "<script></script>";
@@ -19801,12 +19272,12 @@ var objectCreate = Object.create || function(parent) {
 };
 
 var Handlebars = this.Handlebars || (Ember.imports && Ember.imports.Handlebars);
-if (!Handlebars && typeof require === 'function') {
+if(!Handlebars && typeof require === 'function') {
   Handlebars = require('handlebars');
 }
 
-Ember.assert("Ember Handlebars requires Handlebars version 1.0.0. Include a SCRIPT tag in the HTML HEAD linking to the Handlebars file before you link to Ember.", Handlebars);
-Ember.assert("Ember Handlebars requires Handlebars version 1.0.0, COMPILER_REVISION expected: 4, got: " +  Handlebars.COMPILER_REVISION + " - Please note: Builds of master may have other COMPILER_REVISION values.", Handlebars.COMPILER_REVISION === 4);
+Ember.assert("Ember Handlebars requires Handlebars version 1.0.0-rc.4. Include a SCRIPT tag in the HTML HEAD linking to the Handlebars file before you link to Ember.", Handlebars)
+Ember.assert("Ember Handlebars requires Handlebars version 1.0.0-rc.4, COMPILER_REVISION expected: 3, got: " +  Handlebars.COMPILER_REVISION + " – Please note: Builds of master may have other COMPILER_REVISION values.", Handlebars.COMPILER_REVISION === 3);
 
 /**
   Prepares the Handlebars templating library for use inside Ember's view
@@ -19912,7 +19383,7 @@ Ember.Handlebars.helper = function(name, value) {
   } else {
     Ember.Handlebars.registerBoundHelper.apply(null, arguments);
   }
-};
+}
 
 /**
 @class helpers
@@ -19993,12 +19464,12 @@ Ember.Handlebars.Compiler.prototype.mustache = function(mustache) {
   } else if (mustache.params.length || mustache.hash) {
     // no changes required
   } else {
-    var id = new Handlebars.AST.IdNode([{ part: '_triageMustache' }]);
+    var id = new Handlebars.AST.IdNode(['_triageMustache']);
 
     // Update the mustache node to include a hash value indicating whether the original node
     // was escaped. This will allow us to properly escape values when the underlying value
     // changes and we need to re-render the value.
-    if (!mustache.escaped) {
+    if(!mustache.escaped) {
       mustache.hash = mustache.hash || new Handlebars.AST.HashNode([]);
       mustache.hash.pairs.push(["unescaped", new Handlebars.AST.StringNode("true")]);
     }
@@ -20196,7 +19667,7 @@ Ember.Handlebars.registerHelper('helperMissing', function(path, options) {
   var error, view = "";
 
   error = "%@ Handlebars error: Could not find property '%@' on object %@.";
-  if (options.data) {
+  if (options.data){
     view = options.data.view;
   }
   throw new Ember.Error(Ember.String.fmt(error, [view, path, this]));
@@ -20233,7 +19704,7 @@ Ember.Handlebars.registerHelper('helperMissing', function(path, options) {
   Ember.Handlebars.registerBoundHelper('repeat', function(value, options) {
     var count = options.hash.count;
     var a = [];
-    while(a.length < count) {
+    while(a.length < count){
         a.push(value);
     }
     return a.join('');
@@ -20277,7 +19748,7 @@ Ember.Handlebars.registerHelper('helperMissing', function(path, options) {
 
   ```javascript
   Ember.Handlebars.registerBoundHelper('concatenate', function() {
-    var values = Array.prototype.slice.call(arguments, 0, -1);
+    var values = arguments[arguments.length - 1];
     return values.join('||');
   });
   ```
@@ -20429,7 +19900,7 @@ function evaluateMultiPropertyBoundHelper(context, fn, normalizedProperties, opt
 
   view.appendChild(bindView);
 
-  // Assemble list of watched properties that'll re-render this helper.
+  // Assemble liast of watched properties that'll re-render this helper.
   watchedProperties = [];
   for (boundOption in boundOptions) {
     if (boundOptions.hasOwnProperty(boundOption)) {
@@ -20483,7 +19954,7 @@ function evaluateUnboundHelper(context, fn, normalizedProperties, options) {
   @for Ember.Handlebars
   @param {String} template spec
 */
-Ember.Handlebars.template = function(spec) {
+Ember.Handlebars.template = function(spec){
   var t = Handlebars.template(spec);
   t.isTop = true;
   return t;
@@ -20495,17 +19966,10 @@ Ember.Handlebars.template = function(spec) {
 
 (function() {
 /**
- * Mark a string as safe for raw output with Handlebars. If you
- * return HTML from a Handlebars helper, use this function to
- * ensure Handlebars does not escape the HTML.
- *
- * `Ember.String.htmlSafe('<div>someString</div>')`
- *
- * @method htmlSafe
- * @for Ember.String
- * @static
- * @return {Handlebars.SafeString} a string that will not be html escaped by Handlebars
- */
+  @method htmlSafe
+  @for Ember.String
+  @static
+*/
 Ember.String.htmlSafe = function(str) {
   return new Handlebars.SafeString(str);
 };
@@ -20515,15 +19979,11 @@ var htmlSafe = Ember.String.htmlSafe;
 if (Ember.EXTEND_PROTOTYPES === true || Ember.EXTEND_PROTOTYPES.String) {
 
   /**
-   * Use `'<div>someString</div>'.htmlSafe()` to mark a string as being
-   * safe for raw output with Handlebars.
-   *
-   * See `Ember.String.htmlSafe`.
-   *
-   * @method htmlSafe
-   * @for String
-   * @return {Handlebars.SafeString} a string that will not be html escaped by Handlebars
-   */
+    See `Ember.String.htmlSafe`.
+
+    @method htmlSafe
+    @for String
+  */
   String.prototype.htmlSafe = function() {
     return htmlSafe(this);
   };
@@ -21023,7 +20483,7 @@ var forEach = Ember.ArrayPolyfills.forEach;
 
 var EmberHandlebars = Ember.Handlebars, helpers = EmberHandlebars.helpers;
 
-function exists(value) {
+function exists(value){
   return !Ember.isNone(value);
 }
 
@@ -21373,7 +20833,7 @@ EmberHandlebars.registerHelper('unless', function(context, options) {
 
   ```javascript
     AView = Ember.View.extend({
-      someProperty: function() {
+      someProperty: function(){
         return "aValue";
       }.property()
     })
@@ -21662,8 +21122,6 @@ EmberHandlebars.bindClasses = function(context, classBindings, view, bindAttrId,
 
 var get = Ember.get, set = Ember.set;
 var EmberHandlebars = Ember.Handlebars;
-var LOWERCASE_A_Z = /^[a-z]/;
-var VIEW_PREFIX = /^view\./;
 
 EmberHandlebars.ViewHelper = Ember.Object.create({
 
@@ -21775,18 +21233,7 @@ EmberHandlebars.ViewHelper = Ember.Object.create({
         newView;
 
     if ('string' === typeof path) {
-
-      // TODO: this is a lame conditional, this should likely change
-      // but something along these lines will likely need to be added
-      // as deprecation warnings
-      //
-      if (options.types[0] === 'STRING' && LOWERCASE_A_Z.test(path) && !VIEW_PREFIX.test(path)) {
-        Ember.assert("View requires a container", !!data.view.container);
-        newView = data.view.container.lookupFactory('view:' + path);
-      } else {
-        newView = EmberHandlebars.get(thisContext, path, options);
-      }
-
+      newView = EmberHandlebars.get(thisContext, path, options);
       Ember.assert("Unable to find view at path '" + path + "'", !!newView);
     } else {
       newView = path;
@@ -22155,25 +21602,11 @@ Ember.Handlebars.registerHelper('collection', function(path, options) {
   var hash = options.hash, itemHash = {}, match;
 
   // Extract item view class if provided else default to the standard class
-  var collectionPrototype = collectionClass.proto(),
-      itemViewClass;
-
-  if (hash.itemView) {
-    var controller = data.keywords.controller;
-    Ember.assert('itemView given, but no container is available', controller && controller.container);
-    var container = controller.container;
-    itemViewClass = container.resolve('view:' + Ember.String.camelize(hash.itemView));
-    Ember.assert('itemView not found in container', !!itemViewClass);
-  } else if (hash.itemViewClass) {
-    itemViewClass = handlebarsGet(collectionPrototype, hash.itemViewClass, options);
-  } else {
-    itemViewClass = collectionPrototype.itemViewClass;
-  }
-
-  Ember.assert(fmt("%@ #collection: Could not find itemViewClass %@", [data.view, itemViewClass]), !!itemViewClass);
-
+  var itemViewClass, itemViewPath = hash.itemViewClass;
+  var collectionPrototype = collectionClass.proto();
   delete hash.itemViewClass;
-  delete hash.itemView;
+  itemViewClass = itemViewPath ? handlebarsGet(collectionPrototype, itemViewPath, options) : collectionPrototype.itemViewClass;
+  Ember.assert(fmt("%@ #collection: Could not find itemViewClass %@", [data.view, itemViewPath]), !!itemViewClass);
 
   // Go through options passed to the {{collection}} helper and extract options
   // that configure item views instead of the collection itself.
@@ -22181,7 +21614,7 @@ Ember.Handlebars.registerHelper('collection', function(path, options) {
     if (hash.hasOwnProperty(prop)) {
       match = prop.match(/^item(.)(.*)$/);
 
-      if (match && prop !== 'itemController') {
+      if(match && prop !== 'itemController') {
         // Convert itemShouldFoo -> shouldFoo
         itemHash[match[1].toLowerCase() + match[2]] = hash[prop];
         // Delete from hash as this will end up getting passed to the
@@ -22208,7 +21641,7 @@ Ember.Handlebars.registerHelper('collection', function(path, options) {
   }
   if (emptyViewClass) { hash.emptyView = emptyViewClass; }
 
-  if (!hash.keyword) {
+  if(!hash.keyword){
     itemHash._context = Ember.computed.alias('content');
   }
 
@@ -22255,7 +21688,7 @@ var handlebarsGet = Ember.Handlebars.get;
 Ember.Handlebars.registerHelper('unbound', function(property, fn) {
   var options = arguments[arguments.length - 1], helper, context, out;
 
-  if (arguments.length > 2) {
+  if(arguments.length > 2) {
     // Unbound helper call.
     options.data.isUnbound = true;
     helper = Ember.Handlebars.helpers[arguments[0]] || Ember.Handlebars.helperMissing;
@@ -22313,7 +21746,7 @@ Ember.Handlebars.registerHelper('log', function(property, options) {
   @for Ember.Handlebars.helpers
   @param {String} property
 */
-Ember.Handlebars.registerHelper('debugger', function(options) {
+Ember.Handlebars.registerHelper('debugger', function() {
   debugger;
 });
 
@@ -22589,12 +22022,6 @@ GroupedEach.prototype = {
   </div>
   ```
 
-  If an `itemViewClass` is defined on the helper, and therefore the helper is not
-  being used as a block, an `emptyViewClass` can also be provided optionally.
-  The `emptyViewClass` will match the behavior of the `{{else}}` condition
-  described above. That is, the `emptyViewClass` will render if the collection
-  is empty.
-
   ### Representing each item with a Controller.
   By default the controller lookup within an `{{#each}}` block will be
   the controller of the template where the `{{#each}}` was used. If each
@@ -22608,7 +22035,7 @@ GroupedEach.prototype = {
 
   ```javascript
   App.DeveloperController = Ember.ObjectController.extend({
-    isAvailableForHire: function() {
+    isAvailableForHire: function(){
       return !this.get('content.isEmployed') && this.get('content.isSeekingWork');
     }.property('isEmployed', 'isSeekingWork')
   })
@@ -22859,38 +22286,6 @@ Ember.Handlebars.registerHelper('yield', function(options) {
 
 
 (function() {
-/**
-@module ember
-@submodule ember-handlebars
-*/
-
-/**
-  `loc` looks up the string in the localized strings hash.
-  This is a convenient way to localize text. For example:
-
-  ```html
-  <script type="text/x-handlebars" data-template-name="home">
-    {{loc welcome}}
-  </script>
-  ```
-
-  Take note that `welcome` is a string and not an object
-  reference.
-
-  @method loc
-  @for Ember.Handlebars.helpers
-  @param {String} str The string to format
-*/
-
-Ember.Handlebars.registerHelper('loc', function(str) {
-  return Ember.String.loc(str);
-});
-
-})();
-
-
-
-(function() {
 
 })();
 
@@ -22953,7 +22348,7 @@ Ember.Checkbox = Ember.View.extend({
 
   tagName: 'input',
 
-  attributeBindings: ['type', 'checked', 'indeterminate', 'disabled', 'tabindex', 'name'],
+  attributeBindings: ['type', 'checked', 'disabled', 'tabindex', 'name'],
 
   type: "checkbox",
   checked: false,
@@ -23406,7 +22801,6 @@ var set = Ember.set,
     get = Ember.get,
     indexOf = Ember.EnumerableUtils.indexOf,
     indexesOf = Ember.EnumerableUtils.indexesOf,
-    forEach = Ember.EnumerableUtils.forEach,
     replace = Ember.EnumerableUtils.replace,
     isArray = Ember.isArray,
     precompileTemplate = Ember.Handlebars.compile;
@@ -23458,18 +22852,6 @@ Ember.SelectOption = Ember.View.extend({
       return get(this, valuePath);
     }).property(valuePath));
   }, 'parentView.optionValuePath')
-});
-
-Ember.SelectOptgroup = Ember.CollectionView.extend({
-  tagName: 'optgroup',
-  attributeBindings: ['label'],
-
-  selectionBinding: 'parentView.selection',
-  multipleBinding: 'parentView.multiple',
-  optionLabelPathBinding: 'parentView.optionLabelPath',
-  optionValuePathBinding: 'parentView.optionValuePath',
-
-  itemViewClassBinding: 'parentView.optionView'
 });
 
 /**
@@ -23722,8 +23104,8 @@ Ember.Select = Ember.View.extend(
   tagName: 'select',
   classNames: ['ember-select'],
   defaultTemplate: Ember.Handlebars.template(function anonymous(Handlebars,depth0,helpers,partials,data) {
-this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Ember.Handlebars.helpers); data = data || {};
+this.compilerInfo = [3,'>= 1.0.0-rc.4'];
+helpers = helpers || Ember.Handlebars.helpers; data = data || {};
   var buffer = '', stack1, hashTypes, hashContexts, escapeExpression=this.escapeExpression, self=this;
 
 function program1(depth0,data) {
@@ -23739,35 +23121,6 @@ function program1(depth0,data) {
 
 function program3(depth0,data) {
   
-  var stack1, hashTypes, hashContexts;
-  hashTypes = {};
-  hashContexts = {};
-  stack1 = helpers.each.call(depth0, "view.groupedContent", {hash:{},inverse:self.noop,fn:self.program(4, program4, data),contexts:[depth0],types:["ID"],hashContexts:hashContexts,hashTypes:hashTypes,data:data});
-  if(stack1 || stack1 === 0) { data.buffer.push(stack1); }
-  else { data.buffer.push(''); }
-  }
-function program4(depth0,data) {
-  
-  var hashContexts, hashTypes;
-  hashContexts = {'contentBinding': depth0,'labelBinding': depth0};
-  hashTypes = {'contentBinding': "ID",'labelBinding': "ID"};
-  data.buffer.push(escapeExpression(helpers.view.call(depth0, "view.groupView", {hash:{
-    'contentBinding': ("content"),
-    'labelBinding': ("label")
-  },contexts:[depth0],types:["ID"],hashContexts:hashContexts,hashTypes:hashTypes,data:data})));
-  }
-
-function program6(depth0,data) {
-  
-  var stack1, hashTypes, hashContexts;
-  hashTypes = {};
-  hashContexts = {};
-  stack1 = helpers.each.call(depth0, "view.content", {hash:{},inverse:self.noop,fn:self.program(7, program7, data),contexts:[depth0],types:["ID"],hashContexts:hashContexts,hashTypes:hashTypes,data:data});
-  if(stack1 || stack1 === 0) { data.buffer.push(stack1); }
-  else { data.buffer.push(''); }
-  }
-function program7(depth0,data) {
-  
   var hashContexts, hashTypes;
   hashContexts = {'contentBinding': depth0};
   hashTypes = {'contentBinding': "STRING"};
@@ -23782,7 +23135,7 @@ function program7(depth0,data) {
   if(stack1 || stack1 === 0) { data.buffer.push(stack1); }
   hashTypes = {};
   hashContexts = {};
-  stack1 = helpers['if'].call(depth0, "view.optionGroupPath", {hash:{},inverse:self.program(6, program6, data),fn:self.program(3, program3, data),contexts:[depth0],types:["ID"],hashContexts:hashContexts,hashTypes:hashTypes,data:data});
+  stack1 = helpers.each.call(depth0, "view.content", {hash:{},inverse:self.noop,fn:self.program(3, program3, data),contexts:[depth0],types:["ID"],hashContexts:hashContexts,hashTypes:hashTypes,data:data});
   if(stack1 || stack1 === 0) { data.buffer.push(stack1); }
   return buffer;
   
@@ -23883,45 +23236,6 @@ function program7(depth0,data) {
   optionValuePath: 'content',
 
   /**
-    The path of the option group.
-    When this property is used, `content` should be sorted by `optionGroupPath`.
-
-    @property optionGroupPath
-    @type String
-    @default null
-  */
-  optionGroupPath: null,
-
-  /**
-    The view class for optgroup.
-
-    @property groupView
-    @type Ember.View
-    @default Ember.SelectOptgroup
-  */
-  groupView: Ember.SelectOptgroup,
-
-  groupedContent: Ember.computed(function() {
-    var groupPath = get(this, 'optionGroupPath');
-    var groupedContent = Ember.A();
-
-    forEach(get(this, 'content'), function(item) {
-      var label = get(item, groupPath);
-
-      if (get(groupedContent, 'lastObject.label') !== label) {
-        groupedContent.pushObject({
-          label: label,
-          content: Ember.A()
-        });
-      }
-
-      get(groupedContent, 'lastObject.content').push(item);
-    });
-
-    return groupedContent;
-  }).property('optionGroupPath', 'content.@each'),
-
-  /**
     The view class for option.
 
     @property optionView
@@ -23998,9 +23312,9 @@ function program7(depth0,data) {
         content = get(this, 'content'),
         selection = get(this, 'selection');
 
-    if (!content) { return; }
+    if (!content){ return; }
     if (options) {
-      var selectedIndexes = options.map(function() {
+      var selectedIndexes = options.map(function(){
         return this.index - offset;
       }).toArray();
       var newSelection = content.objectsAt(selectedIndexes);
@@ -24089,7 +23403,7 @@ Ember.Handlebars.registerHelper('input', function(options) {
   if (inputType === 'checkbox') {
     return Ember.Handlebars.helpers.view.call(this, Ember.Checkbox, options);
   } else {
-    if (inputType) { hash.type = inputType; }
+    hash.type = inputType;
     hash.onEvent = onEvent || 'enter';
     return Ember.Handlebars.helpers.view.call(this, Ember.TextField, options);
   }
@@ -24345,7 +23659,7 @@ define("route-recognizer",
           results.push(new StarSegment(match[1]));
           names.push(match[1]);
           types.stars++;
-        } else if (segment === "") {
+        } else if(segment === "") {
           results.push(new EpsilonSegment());
         } else {
           results.push(new StaticSegment(segment));
@@ -24757,7 +24071,7 @@ define("route-recognizer",
 
 (function() {
 define("router",
-  ["route-recognizer","rsvp"],
+  ["route-recognizer", "rsvp"],
   function(RouteRecognizer, RSVP) {
     "use strict";
     /**
@@ -24978,9 +24292,7 @@ define("router",
       handleURL: function(url) {
         // Perform a URL-based transition, but don't change
         // the URL afterward, since it already happened.
-        var args = slice.call(arguments);
-        if (url.charAt(0) !== '/') { args[0] = '/' + url; }
-        return doTransition(this, args).method(null);
+        return doTransition(this, arguments).method(null);
       },
 
       /**
@@ -24989,7 +24301,7 @@ define("router",
         @param {String} url a URL to update to
       */
       updateURL: function() {
-        throw new Error("updateURL is not implemented");
+        throw "updateURL is not implemented";
       },
 
       /**
@@ -25064,8 +24376,6 @@ define("router",
 
         if (!targetHandlerInfos) { return false; }
 
-        var recogHandlers = this.recognizer.handlersFor(targetHandlerInfos[targetHandlerInfos.length - 1].name);
-
         for (var i=targetHandlerInfos.length-1; i>=0; i--) {
           handlerInfo = targetHandlerInfos[i];
           if (handlerInfo.name === handlerName) { found = true; }
@@ -25075,13 +24385,7 @@ define("router",
 
             if (handlerInfo.isDynamic) {
               object = contexts.pop();
-
-              if (isParam(object)) {
-                var recogHandler = recogHandlers[i], name = recogHandler.names[0];
-                if (object.toString() !== this.currentParams[name]) { return false; }
-              } else if (handlerInfo.context !== object) { 
-                return false; 
-              }
+              if (handlerInfo.context !== object) { return false; }
             }
           }
         }
@@ -25111,16 +24415,15 @@ define("router",
      */
     function getMatchPoint(router, handlers, objects, inputParams) {
 
-      var matchPoint = handlers.length, 
+      var objectsToMatch = objects.length, 
+          matchPoint = handlers.length, 
           providedModels = {}, i,
           currentHandlerInfos = router.currentHandlerInfos || [],
           params = {},
           oldParams = router.currentParams || {},
           activeTransition = router.activeTransition,
-          handlerParams = {},
-          obj;
+          handlerParams = {};
 
-      objects = slice.call(objects);
       merge(params, inputParams);
    
       for (i = handlers.length - 1; i >= 0; i--) {
@@ -25135,9 +24438,9 @@ define("router",
         if (handlerObj.isDynamic) {
           // URL transition.
 
-          if (obj = getMatchPointObject(objects, handlerName, activeTransition, true, params)) {
+          if (objectsToMatch > 0) {
             hasChanged = true;
-            providedModels[handlerName] = obj;
+            providedModels[handlerName] = objects[--objectsToMatch];
           } else {
             handlerParams[handlerName] = {};
             for (var prop in handlerObj.params) {
@@ -25147,19 +24450,24 @@ define("router",
               handlerParams[handlerName][prop] = params[prop] = newParam;
             }
           }
-        } else if (handlerObj.hasOwnProperty('names')) {
+        } else if (handlerObj.hasOwnProperty('names') && handlerObj.names.length) {
           // Named transition.
 
-          if (objects.length) { hasChanged = true; }
+          if (objectsToMatch > 0) {
+            hasChanged = true;
+            providedModels[handlerName] = objects[--objectsToMatch];
+          } else if (activeTransition && activeTransition.providedModels[handlerName]) {
 
-          if (obj = getMatchPointObject(objects, handlerName, activeTransition, handlerObj.names[0], params)) {
-            providedModels[handlerName] = obj;
+            // Use model from previous transition attempt, preferably the resolved one.
+            hasChanged = true;
+            providedModels[handlerName] = activeTransition.providedModels[handlerName] ||
+                                          activeTransition.resolvedModels[handlerName];
           } else {
             var names = handlerObj.names;
             handlerParams[handlerName] = {};
             for (var j = 0, len = names.length; j < len; ++j) {
               var name = names[j];
-              handlerParams[handlerName][name] = params[name] = params[name] || oldParams[name];
+              handlerParams[handlerName][name] = params[name] = oldParams[name];
             }
           }
         } 
@@ -25167,34 +24475,11 @@ define("router",
         if (hasChanged) { matchPoint = i; }
       }
 
-      if (objects.length > 0) {
-        throw new Error("More context objects were passed than there are dynamic segments for the route: " + handlers[handlers.length - 1].handler);
+      if (objectsToMatch > 0) {
+        throw "More context objects were passed than there are dynamic segments for the route: " + handlers[handlers.length - 1].handler;
       }
 
       return { matchPoint: matchPoint, providedModels: providedModels, params: params, handlerParams: handlerParams };
-    }
-
-    function getMatchPointObject(objects, handlerName, activeTransition, paramName, params) {
-
-      if (objects.length && paramName) {
-
-        var object = objects.pop();
-
-        // If provided object is string or number, treat as param.
-        if (isParam(object)) {
-          params[paramName] = object.toString();
-        } else {
-          return object;
-        }
-      } else if (activeTransition) {
-        // Use model from previous transition attempt, preferably the resolved one.
-        return (paramName && activeTransition.providedModels[handlerName]) ||
-               activeTransition.resolvedModels[handlerName];
-      } 
-    }
-
-    function isParam(object) {
-      return object && (typeof object === "string" || object instanceof String || !isNaN(object));
     }
 
     /**
@@ -25619,12 +24904,11 @@ define("router",
       log(router, seq, "Validation succeeded, finalizing transition;");
 
       // Collect params for URL.
-      var objects = [], providedModels = transition.providedModelsArray.slice();
-      for (var i = handlerInfos.length - 1; i>=0; --i) {
+      var objects = [];
+      for (var i = 0, len = handlerInfos.length; i < len; ++i) {
         var handlerInfo = handlerInfos[i];
         if (handlerInfo.isDynamic) {
-          var providedModel = providedModels.pop();
-          objects.unshift(isParam(providedModel) ? providedModel.toString() : handlerInfo.context);
+          objects.push(handlerInfo.context);
         }
       }
 
@@ -25670,14 +24954,15 @@ define("router",
           handler = handlerInfo.handler,
           handlerName = handlerInfo.name,
           seq = transition.sequence,
-          errorAlreadyHandled = false;
+          errorAlreadyHandled = false,
+          resolvedModel;
 
       if (index < matchPoint) {
         log(router, seq, handlerName + ": using context from already-active handler");
 
         // We're before the match point, so don't run any hooks,
         // just use the already resolved context from the handler.
-        transition.resolvedModels[handlerInfo.name] = handlerInfo.handler.context;
+        resolvedModel = handlerInfo.handler.context;
         return proceed();
       }
 
@@ -25717,8 +25002,8 @@ define("router",
         trigger(handlerInfos.slice(0, index + 1), true, ['error', reason, transition]);
 
         if (handler.error) { 
-          handler.error(reason, transition); 
-        }
+          handler.error(reason, transition); }
+
 
         // Propagate the original error.
         return RSVP.reject(reason);
@@ -25728,15 +25013,13 @@ define("router",
 
         log(router, seq, handlerName + ": calling beforeModel hook");
 
-        var p = handler.beforeModel && handler.beforeModel(transition);
-        return (p instanceof Transition) ? null : p;
+        return handler.beforeModel && handler.beforeModel(transition);
       }
 
       function model() {
         log(router, seq, handlerName + ": resolving model");
 
-        var p = getModel(handlerInfo, transition, handlerParams[handlerName], index >= matchPoint);
-        return (p instanceof Transition) ? null : p;
+        return getModel(handlerInfo, transition, handlerParams[handlerName], index >= matchPoint);
       }
 
       function afterModel(context) {
@@ -25747,16 +25030,14 @@ define("router",
         // want to use the value returned from `afterModel` in any way, but rather
         // always resolve with the original `context` object.
 
-        transition.resolvedModels[handlerInfo.name] = context;
-
-        var p = handler.afterModel && handler.afterModel(context, transition);
-        return (p instanceof Transition) ? null : p;
+        resolvedModel = context;
+        return handler.afterModel && handler.afterModel(resolvedModel, transition);
       }
 
       function proceed() {
         log(router, seq, handlerName + ": validation succeeded, proceeding");
 
-        handlerInfo.context = transition.resolvedModels[handlerInfo.name];
+        handlerInfo.context = transition.resolvedModels[handlerInfo.name] = resolvedModel;
         return validateEntry(transition, handlerInfos, index + 1, matchPoint, handlerParams);
       }
     }
@@ -25788,7 +25069,7 @@ define("router",
         return handler.context;
       }
 
-      if (transition.providedModels.hasOwnProperty(handlerName)) {
+      if (handlerInfo.isDynamic && transition.providedModels.hasOwnProperty(handlerName)) {
         var providedModel = transition.providedModels[handlerName];
         return typeof providedModel === 'function' ? providedModel() : providedModel;
       }
@@ -25847,12 +25128,6 @@ define("router",
     */
     function serialize(handler, model, names) {
 
-      var object = {};
-      if (isParam(model)) {
-        object[names[0]] = model;
-        return object;
-      }
-
       // Use custom serialize if it exists.
       if (handler.serialize) {
         return handler.serialize(model, names);
@@ -25860,7 +25135,7 @@ define("router",
 
       if (names.length !== 1) { return; }
 
-      var name = names[0];
+      var name = names[0], object = {};
 
       if (/_id$/.test(name)) {
         object[name] = model.id;
@@ -25869,7 +25144,6 @@ define("router",
       }
       return object;
     }
-
 
     return Router;
   });
@@ -26106,7 +25380,11 @@ Ember.Router = Ember.Object.extend({
   handleURL: function(url) {
     scheduleLoadingStateEntry(this);
 
-    return this.router.handleURL(url).then(transitionCompleted);
+    var self = this;
+
+    return this.router.handleURL(url).then(function() {
+      transitionCompleted(self);
+    });
   },
 
   transitionTo: function() {
@@ -26275,7 +25553,9 @@ function doTransition(router, method, args) {
   scheduleLoadingStateEntry(router);
 
   var transitionPromise = router.router[method].apply(router.router, args);
-  transitionPromise.then(transitionCompleted);
+  transitionPromise.then(function() {
+    transitionCompleted(router);
+  });
 
   // We want to return the configurable promise object
   // so that callers of this function can use `.method()` on it,
@@ -26309,19 +25589,14 @@ function exitLoadingState(router) {
   router._loadingStateActive = false;
 }
 
-function transitionCompleted(route) {
-  var router = route.router;
+function transitionCompleted(router) {
   router.notifyPropertyChange('url');
   exitLoadingState(router);
 }
 
 Ember.Router.reopenClass({
   map: function(callback) {
-    var router = this.router;
-    if (!router) {
-      router = this.router = new Router();
-      router.callbacks = [];
-    }
+    var router = this.router = new Router();
 
     if (get(this, 'namespace.LOG_TRANSITIONS_INTERNAL')) {
       router.log = Ember.Logger.debug;
@@ -26329,14 +25604,10 @@ Ember.Router.reopenClass({
 
     var dsl = Ember.RouterDSL.map(function() {
       this.resource('application', { path: "/" }, function() {
-        for (var i=0; i < router.callbacks.length; i++) {
-          router.callbacks[i].call(this);
-        }
         callback.call(this);
       });
     });
 
-    router.callbacks.push(callback);
     router.map(dsl.generate());
     return router;
   }
@@ -26564,7 +25835,7 @@ Ember.Route = Ember.Object.extend({
     @method setup
   */
   setup: function(context) {
-    var controller = this.controllerFor(this.controllerName || this.routeName, context);
+    var controller = this.controllerFor(this.routeName, context);
 
     // Assign the route's controller so that it can more easily be
     // referenced in event handlers
@@ -26670,7 +25941,6 @@ Ember.Route = Ember.Object.extend({
     });
     ```
 
-    @method beforeModel
     @param {Transition} transition 
     @return {Promise} if the value returned from this hook is
       a promise, the transition will pause until the transition
@@ -26701,7 +25971,6 @@ Ember.Route = Ember.Object.extend({
     of transition-pausing semantics when a promise is returned
     from this hook. 
 
-    @method afterModel
     @param {Transition} transition 
     @return {Promise} if the value returned from this hook is
       a promise, the transition will pause until the transition
@@ -26772,10 +26041,11 @@ Ember.Route = Ember.Object.extend({
     if (!name && sawParams) { return params; }
     else if (!name) { return; }
 
-    var modelClass = this.container.lookupFactory('model:' + name);
-    var namespace = get(this, 'router.namespace');
+    var className = classify(name),
+        namespace = this.router.namespace,
+        modelClass = namespace[className];
 
-    Ember.assert("You used the dynamic segment " + name + "_id in your router, but " + namespace + "." + classify(name) + " did not exist and you did not override your route's `model` hook.", modelClass);
+    Ember.assert("You used the dynamic segment " + name + "_id in your router, but " + namespace + "." + className + " did not exist and you did not override your route's `model` hook.", modelClass);
     return modelClass.find(value);
   },
 
@@ -26863,7 +26133,7 @@ Ember.Route = Ember.Object.extend({
 
     @method setupController
   */
-  setupController: function(controller, context) {
+  setupController: function(controller, context){
     if (controller && (context !== undefined)) {
       set(controller, 'model', context);
     }
@@ -27027,48 +26297,6 @@ Ember.Route = Ember.Object.extend({
     if (options.outlet === 'main') { this.lastRenderedTemplate = name; }
 
     appendView(this, view, options);
-  },
-
-  /**
-    Disconnects a view that has been rendered into an outlet.
-
-    You may pass any or all of the following options to `disconnectOutlet`:
-
-    * `outlet`: the name of the outlet to clear (default: 'main')
-    * `parentView`: the name of the view containing the outlet to clear
-       (default: the view rendered by the parent route)
-
-    Example:
-
-    ```js
-    App.ApplicationRoute = App.Route.extend({
-      events: {
-        showModal: function(evt) {
-          this.render(evt.modalName, {
-            outlet: 'modal',
-            into: 'application'
-          });
-        },
-        hideModal: function(evt) {
-          this.disconnectOutlet({
-            outlet: 'modal',
-            parentView: 'application'
-          });
-        }
-      }
-    });
-    ```
-
-    @method disconnectOutlet
-    @param {Object} options the options
-  */
-  disconnectOutlet: function(options) {
-    options = options || {};
-    options.parentView = options.parentView ? options.parentView.replace(/\//g, '.') : parentTemplate(this);
-    options.outlet = options.outlet || 'main';
-
-    var parentView = this.router._lookupActiveView(options.parentView);
-    parentView.disconnectOutlet(options.outlet);
   },
 
   willDestroy: function() {
@@ -27265,12 +26493,15 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     return resolveParams(options.context, options.params, { types: types, data: data });
   }
 
-  function createPath(path) {
-    var fullPath = 'paramsContext';
-    if (path !== '') {
-      fullPath += '.' + path;
-    }
-    return fullPath;
+  function args(linkView, router, route) {
+    var passedRouteName = route || linkView.namedRoute, routeName;
+
+    routeName = fullRouteName(router, passedRouteName);
+
+    Ember.assert(fmt("The attempt to linkTo route '%@' failed. The router did not find '%@' in its possible routes: '%@'", [passedRouteName, passedRouteName, Ember.keys(router.router.recognizer.names).join("', '")]), router.hasRoute(routeName));
+
+    var ret = [ routeName ];
+    return ret.concat(resolvedPaths(linkView.parameters));
   }
 
   /**
@@ -27311,16 +26542,6 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     activeClass: 'active',
 
     /**
-      The CSS class to apply to `LinkView`'s element when its `loading`
-      property is `true`.
-
-      @property loadingClass
-      @type String
-      @default loading
-    **/
-    loadingClass: 'loading',
-
-    /**
       The CSS class to apply to a `LinkView`'s element when its `disabled`
       property is `true`.
       
@@ -27340,7 +26561,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     **/
     replace: false,
     attributeBindings: ['href', 'title'],
-    classNameBindings: ['active', 'loading', 'disabled'],
+    classNameBindings: ['active', 'disabled'],
 
     /**
       By default the `{{linkTo}}` helper responds to the `click` event. You
@@ -27369,39 +26590,10 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     **/
 
     init: function() {
-      this._super.apply(this, arguments);
-
+      this._super();
       // Map desired event name to invoke function
       var eventName = get(this, 'eventName');
       this.on(eventName, this, this._invoke);
-
-      var params = this.parameters.params,
-          length = params.length,
-          context = this.parameters.context,
-          self = this,
-          path, paths = Ember.A([]), i;
-
-      set(this, 'paramsContext', context);
-
-      for(i=0; i < length; i++) {
-        paths.pushObject(createPath(params[i]));
-      }
-
-      var observer = function(object, path) {
-        var notify = true, i;
-        for(i=0; i < paths.length; i++) {
-          if (!get(this, paths[i])) {
-            notify = false;
-          }
-        }
-        if (notify) {
-          this.notifyPropertyChange('routeArgs');
-        }
-      };
-
-      for(i=0; i < length; i++) {
-        this.registerObserver(this, paths[i], this, observer);
-      }
     },
 
     /**
@@ -27441,30 +26633,14 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
       @property active
     **/
     active: Ember.computed(function() {
-      var router = get(this, 'router'),
+      var router = this.get('router'),
           params = resolvedPaths(this.parameters),
-          currentWhen = this.currentWhen || get(this, 'namedRoute'),
-          currentWithIndex = currentWhen + '.index',
-          isActive = router.isActive.apply(router, [currentWhen].concat(params)) ||
+          currentWithIndex = this.currentWhen + '.index',
+          isActive = router.isActive.apply(router, [this.currentWhen].concat(params)) ||
                      router.isActive.apply(router, [currentWithIndex].concat(params));
 
       if (isActive) { return get(this, 'activeClass'); }
     }).property('namedRoute', 'router.url'),
-
-    loading: Ember.computed(function() {
-      if (!get(this, 'routeArgs')) { return get(this, 'loadingClass'); }
-    }).property('routeArgs'),
-
-    /**
-      Accessed as a classname binding to apply the `LinkView`'s `activeClass`
-      CSS `class` to the element when the link is active.
-
-      A `LinkView` is considered active when its `currentWhen` property is `true`
-      or the application's current route is the route the `LinkView` would trigger
-      transitions into.
-
-      @property active
-    **/
 
     router: Ember.computed(function() {
       return this.get('controller').container.lookup('router:main');
@@ -27486,13 +26662,8 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
       
       if (get(this, '_isDisabled')) { return false; }
 
-      if (get(this, 'loading')) { 
-        Ember.Logger.warn("This linkTo's parameters are either not yet loaded or point to an invalid route.");
-        return false; 
-      }
-
-      var router = get(this, 'router'),
-          routeArgs = get(this, 'routeArgs');
+      var router = this.get('router'),
+          routeArgs = args(this, router);
 
       if (this.get('replace')) {
         router.replaceWith.apply(router, routeArgs);
@@ -27500,31 +26671,6 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
         router.transitionTo.apply(router, routeArgs);
       }
     },
-
-    routeArgs: Ember.computed(function() {
-
-      var router = get(this, 'router'), 
-          namedRoute = get(this, 'namedRoute'), routeName;
-
-      if (!namedRoute && this.namedRouteBinding) {
-        // The present value of namedRoute is falsy, but since it's a binding
-        // and could be valid later, don't treat as error.
-        return;
-      }
-      namedRoute = fullRouteName(router, namedRoute);
-
-      Ember.assert(fmt("The attempt to linkTo route '%@' failed. The router did not find '%@' in its possible routes: '%@'", [namedRoute, namedRoute, Ember.keys(router.router.recognizer.names).join("', '")]), router.hasRoute(namedRoute));
-
-      var resolvedContexts = resolvedPaths(this.parameters), paramsPresent = true;
-      for (var i = 0, l = resolvedContexts.length; i < l; ++i) {
-        var context = resolvedContexts[i];
-
-        // If contexts aren't present, consider the linkView unloaded.
-        if (context === null || typeof context === 'undefined') { return; }
-      }
-
-      return [ namedRoute ].concat(resolvedContexts);
-    }).property('namedRoute'),
 
     /**
       Sets the element's `href` attribute to the url for
@@ -27538,21 +26684,9 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     href: Ember.computed(function() {
       if (this.get('tagName') !== 'a') { return false; }
 
-      var router = get(this, 'router'),
-          routeArgs = get(this, 'routeArgs');
-
-      return routeArgs ? router.generate.apply(router, routeArgs) : get(this, 'loadingHref');
-    }).property('routeArgs'),
-
-    /**
-      The default href value to use while a linkTo is loading.
-      Only applies when tagName is 'a'
-
-      @property loadingHref
-      @type String
-      @default #
-    */
-    loadingHref: '#'
+      var router = this.get('router');
+      return router.generate.apply(router, args(this, router));
+    })
   });
 
   LinkView.toString = function() { return "LinkView"; };
@@ -27565,7 +26699,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     element:
 
     ```handlebars
-    {{#linkTo 'photoGallery'}}
+    {{#linkTo photoGallery}}
       Great Hamster Photos
     {{/linkTo}}
     ```
@@ -27582,7 +26716,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     a `tagName` option:
 
     ```handlebars
-    {{#linkTo 'photoGallery' tagName="li"}}
+    {{#linkTo photoGallery tagName="li"}}
       Great Hamster Photos
     {{/linkTo}}
     ```
@@ -27611,7 +26745,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     use of `{{linkTo}}`:
 
     ```handlebars
-    {{#linkTo 'photoGallery.recent'}}
+    {{#linkTo photoGallery.recent}}
       Great Hamster Photos from the last week
     {{/linkTo}}
     ```
@@ -27629,7 +26763,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     option:
 
     ```handlebars
-    {{#linkTo 'photoGallery.recent' activeClass="current-url"}}
+    {{#linkTo photoGallery.recent activeClass="current-url"}}
       Great Hamster Photos from the last week
     {{/linkTo}}
     ```
@@ -27649,13 +26783,13 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     the model context of the linked route:
 
     ```javascript
-    App.Router.map(function() {
+    App.Router.map(function(){
       this.resource("photoGallery", {path: "hamster-photos/:photo_id"});
     })
     ```
 
     ```handlebars
-    {{#linkTo 'photoGallery' aPhoto}}
+    {{#linkTo photoGallery aPhoto}}
       {{aPhoto.title}}
     {{/linkTo}}
     ```
@@ -27674,8 +26808,8 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     route with the dynamic segments:
 
     ```javascript
-    App.Router.map(function() {
-      this.resource("photoGallery", {path: "hamster-photos/:photo_id"}, function() {
+    App.Router.map(function(){
+      this.resource("photoGallery", {path: "hamster-photos/:photo_id"}, function(){
         this.route("comment", {path: "comments/:comment_id"});
       });
     });
@@ -27683,7 +26817,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     This argument will become the model context of the linked route:
 
     ```handlebars
-    {{#linkTo 'photoGallery.comment' aPhoto comment}}
+    {{#linkTo photoGallery.comment aPhoto comment}}
       {{comment.body}}
     {{/linkTo}}
     ```
@@ -27723,22 +26857,13 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     @return {String} HTML string
   */
   Ember.Handlebars.registerHelper('linkTo', function(name) {
-    var options = [].slice.call(arguments, -1)[0],
-        params = [].slice.call(arguments, 1, -1);
+    var options = [].slice.call(arguments, -1)[0];
+    var params = [].slice.call(arguments, 1, -1);
 
     var hash = options.hash;
-      
-    if (options.types[0] === "ID") {
-      if (Ember.ENV.HELPER_PARAM_LOOKUPS) {
-        hash.namedRouteBinding = name;
-      } else {
-        Ember.deprecate("You provided a quoteless destination route parameter of " + name + " to the linkTo helper. Soon, this will perform a property lookup, rather than be treated as a string. To get rid of this warning, wrap " + name + " in quotes. To opt in to this new behavior, set ENV.HELPER_PARAM_LOOKUPS = true");
-        hash.namedRoute = name;
-      }
-    } else {
-      hash.namedRoute = name;
-    }
 
+    hash.namedRoute = name;
+    hash.currentWhen = hash.currentWhen || name;
     hash.disabledBinding = hash.disabledWhen;
 
     hash.parameters = {
@@ -27749,8 +26874,8 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
 
     return Ember.Handlebars.helpers.view.call(this, LinkView, options);
   });
-});
 
+});
 
 
 })();
@@ -27843,7 +26968,7 @@ Ember.onLoad('Ember.Handlebars', function(Handlebars) {
     }
 
     outletSource = options.data.view;
-    while (!(outletSource.get('template.isTop'))) {
+    while (!(outletSource.get('template.isTop'))){
       outletSource = outletSource.get('_parentView');
     }
 
@@ -28722,7 +27847,7 @@ Ember.HashLocation = Ember.Object.extend({
   willDestroy: function() {
     var guid = Ember.guidFor(this);
 
-    Ember.$(window).off('hashchange.ember-location-'+guid);
+    Ember.$(window).unbind('hashchange.ember-location-'+guid);
   }
 });
 
@@ -28740,7 +27865,6 @@ Ember.Location.registerImplementation('hash', Ember.HashLocation);
 
 var get = Ember.get, set = Ember.set;
 var popstateFired = false;
-var supportsHistoryState = window.history && 'state' in window.history;
 
 /**
   Ember.HistoryLocation implements the location API using the browser's
@@ -28803,10 +27927,9 @@ Ember.HistoryLocation = Ember.Object.extend({
     @param path {String}
   */
   setURL: function(path) {
-    var state = this.getState();
     path = this.formatURL(path);
 
-    if (state && state.path !== path) {
+    if (this.getState() && this.getState().path !== path) {
       this.pushState(path);
     }
   },
@@ -28821,10 +27944,9 @@ Ember.HistoryLocation = Ember.Object.extend({
     @param path {String}
   */
   replaceURL: function(path) {
-    var state = this.getState();
     path = this.formatURL(path);
 
-    if (state && state.path !== path) {
+    if (this.getState() && this.getState().path !== path) {
       this.replaceState(path);
     }
   },
@@ -28833,13 +27955,11 @@ Ember.HistoryLocation = Ember.Object.extend({
    @private
 
    Get the current `history.state`
-   Polyfill checks for native browser support and falls back to retrieving
-   from a private _historyState variable
 
    @method getState
   */
   getState: function() {
-    return supportsHistoryState ? get(this, 'history').state : this._historyState;
+    return get(this, 'history').state;
   },
 
   /**
@@ -28851,15 +27971,7 @@ Ember.HistoryLocation = Ember.Object.extend({
    @param path {String}
   */
   pushState: function(path) {
-    var state = { path: path };
-
-    get(this, 'history').pushState(state, null, path);
-
-    // store state if browser doesn't support `history.state`
-    if (!supportsHistoryState) {
-      this._historyState = state;
-    }
-
+    get(this, 'history').pushState({ path: path }, null, path);
     // used for webkit workaround
     this._previousURL = this.getURL();
   },
@@ -28873,15 +27985,7 @@ Ember.HistoryLocation = Ember.Object.extend({
    @param path {String}
   */
   replaceState: function(path) {
-    var state = { path: path };
-
-    get(this, 'history').replaceState(state, null, path);
-
-    // store state if browser doesn't support `history.state`
-    if (!supportsHistoryState) {
-      this._historyState = state;
-    }
-
+    get(this, 'history').replaceState({ path: path }, null, path);
     // used for webkit workaround
     this._previousURL = this.getURL();
   },
@@ -28901,7 +28005,7 @@ Ember.HistoryLocation = Ember.Object.extend({
 
     Ember.$(window).on('popstate.ember-location-'+guid, function(e) {
       // Ignore initial page load popstate event in Chrome
-      if (!popstateFired) {
+      if(!popstateFired) {
         popstateFired = true;
         if (self.getURL() === self._previousURL) { return; }
       }
@@ -28930,7 +28034,7 @@ Ember.HistoryLocation = Ember.Object.extend({
   willDestroy: function() {
     var guid = Ember.guidFor(this);
 
-    Ember.$(window).off('popstate.ember-location-'+guid);
+    Ember.$(window).unbind('popstate.ember-location-'+guid);
   }
 });
 
@@ -29141,7 +28245,6 @@ var get = Ember.get,
   'view:blog/post' //=> Blog.PostView
   'view:basic' //=> Ember.View
   'foo:post' //=> App.PostFoo
-  'model:post' //=> App.Post
   ```
 
   @class DefaultResolver
@@ -29168,11 +28271,6 @@ Ember.DefaultResolver = Ember.Object.extend({
   resolve: function(fullName) {
     var parsedName = this.parseName(fullName),
         typeSpecificResolveMethod = this[parsedName.resolveMethodName];
-
-    if (!parsedName.name || !parsedName.type) {
-      throw new TypeError("Invalid fullName: `" + fullName + "`, must of of the form `type:name` ");
-    }
-
     if (typeSpecificResolveMethod) {
       var resolved = typeSpecificResolveMethod.call(this, parsedName);
       if (resolved) { return resolved; }
@@ -29266,17 +28364,6 @@ Ember.DefaultResolver = Ember.Object.extend({
   resolveView: function(parsedName) {
     this.useRouterNaming(parsedName);
     return this.resolveOther(parsedName);
-  },
-
-  /**
-    @protected
-    @method resolveModel
-  */
-  resolveModel: function(parsedName) {
-    var className = classify(parsedName.name),
-        factory = get(parsedName.root, className);
-
-     if (factory) { return factory; }
   },
   /**
     Look up the specified object (from parsedName) on the appropriate
@@ -29538,7 +28625,7 @@ var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin
 
     this.scheduleInitialize();
 
-    if (Ember.LOG_VERSION) {
+    if ( Ember.LOG_VERSION ) {
       Ember.LOG_VERSION = false; // we only need to see this once per Application#init
       Ember.debug('-------------------------------');
       Ember.debug('Ember.VERSION : ' + Ember.VERSION);
@@ -29617,7 +28704,7 @@ var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin
     if (!this.$ || this.$.isReady) {
       Ember.run.schedule('actions', self, '_initialize');
     } else {
-      this.$().ready(function() {
+      this.$().ready(function(){
         Ember.run(self, '_initialize');
       });
     }
@@ -29706,7 +28793,7 @@ var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin
     @param  property {String}
     @param  injectionName {String}
   **/
-  inject: function() {
+  inject: function(){
     var container = this.__container__;
     container.injection.apply(container, arguments);
   },
@@ -29722,7 +28809,7 @@ var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin
 
     @method initialize
    **/
-  initialize: function() {
+  initialize: function(){
     Ember.deprecate('Calling initialize manually is not supported. Please see Ember.Application#advanceReadiness and Ember.Application#deferReadiness');
   },
   /**
@@ -29768,7 +28855,7 @@ var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin
 
     var App;
 
-    Ember.run(function() {
+    Ember.run(function(){
       App = Ember.Application.create();
     });
 
@@ -29778,11 +28865,11 @@ var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin
       }
     });
 
-    test("first test", function() {
+    test("first test", function(){
       // App is freshly reset
     });
 
-    test("first test", function() {
+    test("first test", function(){
       // App is again freshly reset
     });
     ```
@@ -29797,7 +28884,7 @@ var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin
 
     var App;
 
-    Ember.run(function() {
+    Ember.run(function(){
       App = Ember.Application.create();
     });
 
@@ -29810,10 +28897,10 @@ var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin
       }
     });
 
-    test("first test", function() {
+    test("first test", function(){
       ok(true, 'something before app is initialized');
 
-      Ember.run(function() {
+      Ember.run(function(){
         App.advanceReadiness();
       });
       ok(true, 'something after app is initialized');
@@ -29833,8 +28920,9 @@ var Application = Ember.Application = Ember.Namespace.extend(Ember.DeferredMixin
 
       this.buildContainer();
 
-      Ember.run.schedule('actions', this, function() {
+      Ember.run.schedule('actions', this, function(){
         this._initialize();
+        this.startRouting();
       });
     }
 
@@ -30159,7 +29247,7 @@ Ember.ControllerMixin.reopen({
     this._super.apply(this, arguments);
 
     // Structure asserts to still do verification but not string concat in production
-    if (!verifyDependencies(this)) {
+    if(!verifyDependencies(this)) {
       Ember.assert("Missing dependencies", false);
     }
   },
@@ -30419,7 +29507,7 @@ Ember.State.reopenClass({
 
     bManager = Ember.StateManager.create({
       stateOne: Ember.State.create({
-        changeToStateTwo: function(manager, context) {
+        changeToStateTwo: function(manager, context){
           manager.transitionTo('stateTwo', context)
         }
       }),
@@ -30747,7 +29835,7 @@ var sendEvent = function(eventName, sendRecursiveArguments, isUnhandledPass) {
 
   ```javascript
   managerC = Ember.StateManager.create({
-    initialState: function() {
+    initialState: function(){
       if (someLogic) {
         return 'active';
       } else {
@@ -30790,12 +29878,12 @@ var sendEvent = function(eventName, sendRecursiveArguments, isUnhandledPass) {
   robotManager = Ember.StateManager.create({
     initialState: 'poweredDown',
     poweredDown: Ember.State.create({
-      exit: function(stateManager) {
+      exit: function(stateManager){
         console.log("exiting the poweredDown state")
       }
     }),
     poweredUp: Ember.State.create({
-      enter: function(stateManager) {
+      enter: function(stateManager){
         console.log("entering the poweredUp state. Destroy all humans.")
       }
     })
@@ -30818,12 +29906,12 @@ var sendEvent = function(eventName, sendRecursiveArguments, isUnhandledPass) {
   robotManager = Ember.StateManager.create({
     initialState: 'poweredDown',
     poweredDown: Ember.State.create({
-      exit: function(stateManager) {
+      exit: function(stateManager){
         console.log("exiting the poweredDown state")
       }
     }),
     poweredUp: Ember.State.create({
-      enter: function(stateManager) {
+      enter: function(stateManager){
         console.log("entering the poweredUp state. Destroy all humans.")
       }
     })
@@ -30886,37 +29974,37 @@ var sendEvent = function(eventName, sendRecursiveArguments, isUnhandledPass) {
   robotManager = Ember.StateManager.create({
     initialState: 'poweredDown',
     poweredDown: Ember.State.create({
-      enter: function() {},
-      exit: function() {
+      enter: function(){},
+      exit: function(){
         console.log("exited poweredDown state")
       },
       charging: Ember.State.create({
-        enter: function() {},
-        exit: function() {}
+        enter: function(){},
+        exit: function(){}
       }),
       charged: Ember.State.create({
-        enter: function() {
+        enter: function(){
           console.log("entered charged state")
         },
-        exit: function() {
+        exit: function(){
           console.log("exited charged state")
         }
       })
     }),
     poweredUp: Ember.State.create({
-      enter: function() {
+      enter: function(){
         console.log("entered poweredUp state")
       },
-      exit: function() {},
+      exit: function(){},
       mobile: Ember.State.create({
-        enter: function() {
+        enter: function(){
           console.log("entered mobile state")
         },
-        exit: function() {}
+        exit: function(){}
       }),
       stationary: Ember.State.create({
-        enter: function() {},
-        exit: function() {}
+        enter: function(){},
+        exit: function(){}
       })
     })
   })
@@ -30964,7 +30052,7 @@ var sendEvent = function(eventName, sendRecursiveArguments, isUnhandledPass) {
     initialState: 'stateOne.substateOne.subsubstateOne',
     stateOne: Ember.State.create({
       substateOne: Ember.State.create({
-        anAction: function(manager, context) {
+        anAction: function(manager, context){
           console.log("an action was called")
         },
         subsubstateOne: Ember.State.create({})
@@ -31027,10 +30115,10 @@ var sendEvent = function(eventName, sendRecursiveArguments, isUnhandledPass) {
       })
     }),
     stateTwo: Ember.State.create({
-      anAction: function(manager, context) {
-        // will not be called below because it is
-        // not a parent of the current state
-      }
+     anAction: function(manager, context){
+       // will not be called below because it is
+       // not a parent of the current state
+     }
     })
   })
 
@@ -31048,18 +30136,18 @@ var sendEvent = function(eventName, sendRecursiveArguments, isUnhandledPass) {
     initialState: 'poweredDown.charging',
     poweredDown: Ember.State.create({
       charging: Ember.State.create({
-        chargeComplete: function(manager, context) {
+        chargeComplete: function(manager, context){
           manager.transitionTo('charged')
         }
       }),
       charged: Ember.State.create({
-        boot: function(manager, context) {
+        boot: function(manager, context){
           manager.transitionTo('poweredUp')
         }
       })
     }),
     poweredUp: Ember.State.create({
-      beginExtermination: function(manager, context) {
+      beginExtermination: function(manager, context){
         manager.transitionTo('rampaging')
       },
       rampaging: Ember.State.create()
@@ -31098,7 +30186,7 @@ var sendEvent = function(eventName, sendRecursiveArguments, isUnhandledPass) {
 
   bManager = Ember.StateManager.create({
     stateOne: Ember.State.create({
-      changeToStateTwo: function(manager, context) {
+      changeToStateTwo: function(manager, context){
         manager.transitionTo('stateTwo', context)
       }
     }),
@@ -31486,9 +30574,9 @@ Ember.Test = {
 
     For example:
     ```javascript
-    Ember.Test.registerHelper('boot', function(app) {
+    Ember.Test.registerHelper('boot', function(app)) {
       Ember.run(app, app.deferReadiness);
-    });
+    }
     ```
 
     This helper can later be called without arguments
@@ -31619,8 +30707,6 @@ Ember.Application.reopen({
   testHelpers: {},
 
   setupForTesting: function() {
-    Ember.testing = true;
-
     this.deferReadiness();
 
     this.Router.reopen({
@@ -31653,59 +30739,6 @@ Ember.Application.reopen({
       delete originalMethods[name];
     }
   }
-});
-
-})();
-
-
-
-(function() {
-/**
- * @module ember
- * @sub-module ember-testing
- */
-
-var $ = Ember.$;
-
-function testCheckboxClick(handler) {
-  $('<input type="checkbox">')
-    .css({ position: 'absolute', left: '-1000px', top: '-1000px' })
-    .appendTo('body')
-    .on('click', handler)
-    .click()
-    .remove();
-}
-
-$(function() {
-  /**
-   * Determine whether a checkbox checked using jQuery's "click" method will have
-   * the correct value for its checked property. In some old versions of jQuery
-   * (e.g. 1.8.3) this does not behave correctly.
-   *
-   * If we determine that the current jQuery version exhibits this behavior,
-   * patch it to work correctly as in the commit for the actual fix:
-   * https://github.com/jquery/jquery/commit/1fb2f92.
-   */
-  testCheckboxClick(function() {
-    if (!this.checked && !$.event.special.click) {
-      $.event.special.click = {
-        // For checkbox, fire native event so checked state will be right
-        trigger: function() {
-          if ($.nodeName( this, "input" ) && this.type === "checkbox" && this.click) {
-            this.click();
-            return false;
-          }
-        }
-      };
-    }
-  });
-
-  /**
-   * Try again to verify that the patch took effect or blow up.
-   */
-  testCheckboxClick(function() {
-    Ember.warn("clicked checkboxes should be checked! the jQuery patch didn't work", this.checked);
-  });
 });
 
 })();
@@ -31794,11 +30827,6 @@ Test.QUnitAdapter = Test.Adapter.extend({
 
 
 (function() {
-/**
-* @module ember
-* @sub-module ember-testing
-*/
-
 var get = Ember.get,
     Test = Ember.Test,
     helper = Test.registerHelper,
@@ -31825,31 +30853,7 @@ function visit(app, url) {
 
 function click(app, selector, context) {
   var $el = findWithAssert(app, selector, context);
-  Ember.run($el, 'mousedown');
-
-  if ($el.is(':input')) {
-    var type = $el.prop('type');
-    if (type !== 'checkbox' && type !== 'radio' && type !== 'hidden') {
-      Ember.run($el, 'focus');
-    }
-  }
-
-  Ember.run($el, 'mouseup');
   Ember.run($el, 'click');
-
-  return wait(app);
-}
-
-function keyEvent(app, selector, context, type, keyCode) {
-  var $el;
-  if (typeof keyCode === 'undefined') {
-    keyCode = type;
-    type = context;
-    context = null;
-  }
-  $el = findWithAssert(app, selector, context);
-  var event = Ember.$.Event(type, { keyCode: keyCode });
-  Ember.run($el, 'trigger', event);
   return wait(app);
 }
 
@@ -31951,113 +30955,11 @@ function chain(app, promise, fn) {
   };
 }
 
-/**
-* Loads a route, sets up any controllers, and renders any templates associated
-* with the route as though a real user had triggered the route change while
-* using your app.
-*
-* Example:
-* 
-* ```
-* visit('posts/index').then(function() {
-*   // assert something
-* });
-* ```
-*
-* @method visit
-* @param {String} url the name of the route 
-* @returns {RSVP.Promise}
-*/
+// expose these methods as test helpers
 helper('visit', visit);
-
-/**
-* Clicks an element and triggers any actions triggered by the element's `click`
-* event.
-*
-* Example:
-*
-* ```
-* click('.some-jQuery-selector').then(function() {
-*  // assert something
-* });
-* ```
-*
-* @method click
-* @param {String} selector jQuery selector for finding element on the DOM
-* @returns {RSVP.Promise}
-*/
 helper('click', click);
-
-/**
-* Simulates a key event, e.g. `keypress`, `keydown`, `keyup` with the desired keyCode
-*
-* Example:
-*
-* ```
-* keyEvent('.some-jQuery-selector', 'keypress', 13).then(function() {
-*  // assert something
-* });
-* ```
-*
-* @method keyEvent
-* @param {String} selector jQuery selector for finding element on the DOM
-* @param {String} the type of key event, e.g. `keypress`, `keydown`, `keyup`
-* @param {Number} the keyCode of the simulated key event
-* @returns {RSVP.Promise}
-*/
-helper('keyEvent', keyEvent);
-
-/**
-* Fills in an input element with some text.
-*
-* Example:
-*
-* ```
-* fillIn('#email', 'you@example.com').then(function() {
-*   // assert something
-* });
-* ```
-*
-* @method fillIn
-* @param {String} selector jQuery selector finding an input element on the DOM
-* to fill text with
-* @param {String} text text to place inside the input element
-* @returns {RSVP.Promise}
-*/
 helper('fillIn', fillIn);
-
-/**
-* Finds an element in the context of the app's container element. A simple alias
-* for `app.$(selector)`.
-*
-* Example:
-*
-* ```
-* var $el = find('.my-selector);
-* ```
-*
-* @method find
-* @param {String} selector jQuery string selector for element lookup
-* @returns {Object} jQuery object representing the results of the query
-*/
 helper('find', find);
-
-/**
-*
-* Like `find`, but throws an error if the element selector returns no results
-*
-* Example:
-*
-* ```
-* var $el = findWithAssert('.doesnt-exist'); // throws error
-* ```
-*
-* @method findWithAssert
-* @param {String} selector jQuery selector string for finding an element within
-* the DOM
-* @return {Object} jQuery object representing the results of the query
-* @throws {Error} throws error if jQuery object returned has a length of 0
-*/
 helper('findWithAssert', findWithAssert);
 helper('wait', wait);
 

--- a/vendor/handlebars/handlebars.js
+++ b/vendor/handlebars/handlebars.js
@@ -29,14 +29,13 @@ var Handlebars = {};
 ;
 // lib/handlebars/base.js
 
-Handlebars.VERSION = "1.0.0";
-Handlebars.COMPILER_REVISION = 4;
+Handlebars.VERSION = "1.0.0-rc.4";
+Handlebars.COMPILER_REVISION = 3;
 
 Handlebars.REVISION_CHANGES = {
   1: '<= 1.0.rc.2', // 1.0.rc.2 is actually rev2 but doesn't report it
   2: '== 1.0.0-rc.3',
-  3: '== 1.0.0-rc.4',
-  4: '>= 1.0.0'
+  3: '>= 1.0.0-rc.4'
 };
 
 Handlebars.helpers  = {};
@@ -68,7 +67,7 @@ Handlebars.registerHelper('helperMissing', function(arg) {
   if(arguments.length === 2) {
     return undefined;
   } else {
-    throw new Error("Missing helper: '" + arg + "'");
+    throw new Error("Could not find property '" + arg + "'");
   }
 });
 
@@ -125,9 +124,6 @@ Handlebars.registerHelper('each', function(context, options) {
   var fn = options.fn, inverse = options.inverse;
   var i = 0, ret = "", data;
 
-  var type = toString.call(context);
-  if(type === functionType) { context = context.call(this); }
-
   if (options.data) {
     data = Handlebars.createFrame(options.data);
   }
@@ -156,25 +152,22 @@ Handlebars.registerHelper('each', function(context, options) {
   return ret;
 });
 
-Handlebars.registerHelper('if', function(conditional, options) {
-  var type = toString.call(conditional);
-  if(type === functionType) { conditional = conditional.call(this); }
+Handlebars.registerHelper('if', function(context, options) {
+  var type = toString.call(context);
+  if(type === functionType) { context = context.call(this); }
 
-  if(!conditional || Handlebars.Utils.isEmpty(conditional)) {
+  if(!context || Handlebars.Utils.isEmpty(context)) {
     return options.inverse(this);
   } else {
     return options.fn(this);
   }
 });
 
-Handlebars.registerHelper('unless', function(conditional, options) {
-  return Handlebars.helpers['if'].call(this, conditional, {fn: options.inverse, inverse: options.fn});
+Handlebars.registerHelper('unless', function(context, options) {
+  return Handlebars.helpers['if'].call(this, context, {fn: options.inverse, inverse: options.fn});
 });
 
 Handlebars.registerHelper('with', function(context, options) {
-  var type = toString.call(context);
-  if(type === functionType) { context = context.call(this); }
-
   if (!Handlebars.Utils.isEmpty(context)) return options.fn(context);
 });
 
@@ -188,9 +181,9 @@ Handlebars.registerHelper('log', function(context, options) {
 var handlebars = (function(){
 var parser = {trace: function trace() { },
 yy: {},
-symbols_: {"error":2,"root":3,"program":4,"EOF":5,"simpleInverse":6,"statements":7,"statement":8,"openInverse":9,"closeBlock":10,"openBlock":11,"mustache":12,"partial":13,"CONTENT":14,"COMMENT":15,"OPEN_BLOCK":16,"inMustache":17,"CLOSE":18,"OPEN_INVERSE":19,"OPEN_ENDBLOCK":20,"path":21,"OPEN":22,"OPEN_UNESCAPED":23,"CLOSE_UNESCAPED":24,"OPEN_PARTIAL":25,"partialName":26,"params":27,"hash":28,"dataName":29,"param":30,"STRING":31,"INTEGER":32,"BOOLEAN":33,"hashSegments":34,"hashSegment":35,"ID":36,"EQUALS":37,"DATA":38,"pathSegments":39,"SEP":40,"$accept":0,"$end":1},
-terminals_: {2:"error",5:"EOF",14:"CONTENT",15:"COMMENT",16:"OPEN_BLOCK",18:"CLOSE",19:"OPEN_INVERSE",20:"OPEN_ENDBLOCK",22:"OPEN",23:"OPEN_UNESCAPED",24:"CLOSE_UNESCAPED",25:"OPEN_PARTIAL",31:"STRING",32:"INTEGER",33:"BOOLEAN",36:"ID",37:"EQUALS",38:"DATA",40:"SEP"},
-productions_: [0,[3,2],[4,2],[4,3],[4,2],[4,1],[4,1],[4,0],[7,1],[7,2],[8,3],[8,3],[8,1],[8,1],[8,1],[8,1],[11,3],[9,3],[10,3],[12,3],[12,3],[13,3],[13,4],[6,2],[17,3],[17,2],[17,2],[17,1],[17,1],[27,2],[27,1],[30,1],[30,1],[30,1],[30,1],[30,1],[28,1],[34,2],[34,1],[35,3],[35,3],[35,3],[35,3],[35,3],[26,1],[26,1],[26,1],[29,2],[21,1],[39,3],[39,1]],
+symbols_: {"error":2,"root":3,"program":4,"EOF":5,"simpleInverse":6,"statements":7,"statement":8,"openInverse":9,"closeBlock":10,"openBlock":11,"mustache":12,"partial":13,"CONTENT":14,"COMMENT":15,"OPEN_BLOCK":16,"inMustache":17,"CLOSE":18,"OPEN_INVERSE":19,"OPEN_ENDBLOCK":20,"path":21,"OPEN":22,"OPEN_UNESCAPED":23,"OPEN_PARTIAL":24,"partialName":25,"params":26,"hash":27,"DATA":28,"param":29,"STRING":30,"INTEGER":31,"BOOLEAN":32,"hashSegments":33,"hashSegment":34,"ID":35,"EQUALS":36,"PARTIAL_NAME":37,"pathSegments":38,"SEP":39,"$accept":0,"$end":1},
+terminals_: {2:"error",5:"EOF",14:"CONTENT",15:"COMMENT",16:"OPEN_BLOCK",18:"CLOSE",19:"OPEN_INVERSE",20:"OPEN_ENDBLOCK",22:"OPEN",23:"OPEN_UNESCAPED",24:"OPEN_PARTIAL",28:"DATA",30:"STRING",31:"INTEGER",32:"BOOLEAN",35:"ID",36:"EQUALS",37:"PARTIAL_NAME",39:"SEP"},
+productions_: [0,[3,2],[4,2],[4,3],[4,2],[4,1],[4,1],[4,0],[7,1],[7,2],[8,3],[8,3],[8,1],[8,1],[8,1],[8,1],[11,3],[9,3],[10,3],[12,3],[12,3],[13,3],[13,4],[6,2],[17,3],[17,2],[17,2],[17,1],[17,1],[26,2],[26,1],[29,1],[29,1],[29,1],[29,1],[29,1],[27,1],[33,2],[33,1],[34,3],[34,3],[34,3],[34,3],[34,3],[25,1],[21,1],[38,3],[38,1]],
 performAction: function anonymous(yytext,yyleng,yylineno,yy,yystate,$$,_$) {
 
 var $0 = $$.length - 1;
@@ -231,10 +224,7 @@ case 17: this.$ = new yy.MustacheNode($$[$0-1][0], $$[$0-1][1]);
 break;
 case 18: this.$ = $$[$0-1]; 
 break;
-case 19:
-    // Parsing out the '&' escape token at this level saves ~500 bytes after min due to the removal of one parser node.
-    this.$ = new yy.MustacheNode($$[$0-1][0], $$[$0-1][1], $$[$0-2][2] === '&');
-  
+case 19: this.$ = new yy.MustacheNode($$[$0-1][0], $$[$0-1][1]); 
 break;
 case 20: this.$ = new yy.MustacheNode($$[$0-1][0], $$[$0-1][1], true); 
 break;
@@ -252,7 +242,7 @@ case 26: this.$ = [[$$[$0-1]], $$[$0]];
 break;
 case 27: this.$ = [[$$[$0]], null]; 
 break;
-case 28: this.$ = [[$$[$0]], null]; 
+case 28: this.$ = [[new yy.DataNode($$[$0])], null]; 
 break;
 case 29: $$[$0-1].push($$[$0]); this.$ = $$[$0-1]; 
 break;
@@ -266,7 +256,7 @@ case 33: this.$ = new yy.IntegerNode($$[$0]);
 break;
 case 34: this.$ = new yy.BooleanNode($$[$0]); 
 break;
-case 35: this.$ = $$[$0]; 
+case 35: this.$ = new yy.DataNode($$[$0]); 
 break;
 case 36: this.$ = new yy.HashNode($$[$0]); 
 break;
@@ -282,26 +272,20 @@ case 41: this.$ = [$$[$0-2], new yy.IntegerNode($$[$0])];
 break;
 case 42: this.$ = [$$[$0-2], new yy.BooleanNode($$[$0])]; 
 break;
-case 43: this.$ = [$$[$0-2], $$[$0]]; 
+case 43: this.$ = [$$[$0-2], new yy.DataNode($$[$0])]; 
 break;
 case 44: this.$ = new yy.PartialNameNode($$[$0]); 
 break;
-case 45: this.$ = new yy.PartialNameNode(new yy.StringNode($$[$0])); 
+case 45: this.$ = new yy.IdNode($$[$0]); 
 break;
-case 46: this.$ = new yy.PartialNameNode(new yy.IntegerNode($$[$0])); 
+case 46: $$[$0-2].push($$[$0]); this.$ = $$[$0-2]; 
 break;
-case 47: this.$ = new yy.DataNode($$[$0]); 
-break;
-case 48: this.$ = new yy.IdNode($$[$0]); 
-break;
-case 49: $$[$0-2].push({part: $$[$0], separator: $$[$0-1]}); this.$ = $$[$0-2]; 
-break;
-case 50: this.$ = [{part: $$[$0]}]; 
+case 47: this.$ = [$$[$0]]; 
 break;
 }
 },
-table: [{3:1,4:2,5:[2,7],6:3,7:4,8:6,9:7,11:8,12:9,13:10,14:[1,11],15:[1,12],16:[1,13],19:[1,5],22:[1,14],23:[1,15],25:[1,16]},{1:[3]},{5:[1,17]},{5:[2,6],7:18,8:6,9:7,11:8,12:9,13:10,14:[1,11],15:[1,12],16:[1,13],19:[1,19],20:[2,6],22:[1,14],23:[1,15],25:[1,16]},{5:[2,5],6:20,8:21,9:7,11:8,12:9,13:10,14:[1,11],15:[1,12],16:[1,13],19:[1,5],20:[2,5],22:[1,14],23:[1,15],25:[1,16]},{17:23,18:[1,22],21:24,29:25,36:[1,28],38:[1,27],39:26},{5:[2,8],14:[2,8],15:[2,8],16:[2,8],19:[2,8],20:[2,8],22:[2,8],23:[2,8],25:[2,8]},{4:29,6:3,7:4,8:6,9:7,11:8,12:9,13:10,14:[1,11],15:[1,12],16:[1,13],19:[1,5],20:[2,7],22:[1,14],23:[1,15],25:[1,16]},{4:30,6:3,7:4,8:6,9:7,11:8,12:9,13:10,14:[1,11],15:[1,12],16:[1,13],19:[1,5],20:[2,7],22:[1,14],23:[1,15],25:[1,16]},{5:[2,12],14:[2,12],15:[2,12],16:[2,12],19:[2,12],20:[2,12],22:[2,12],23:[2,12],25:[2,12]},{5:[2,13],14:[2,13],15:[2,13],16:[2,13],19:[2,13],20:[2,13],22:[2,13],23:[2,13],25:[2,13]},{5:[2,14],14:[2,14],15:[2,14],16:[2,14],19:[2,14],20:[2,14],22:[2,14],23:[2,14],25:[2,14]},{5:[2,15],14:[2,15],15:[2,15],16:[2,15],19:[2,15],20:[2,15],22:[2,15],23:[2,15],25:[2,15]},{17:31,21:24,29:25,36:[1,28],38:[1,27],39:26},{17:32,21:24,29:25,36:[1,28],38:[1,27],39:26},{17:33,21:24,29:25,36:[1,28],38:[1,27],39:26},{21:35,26:34,31:[1,36],32:[1,37],36:[1,28],39:26},{1:[2,1]},{5:[2,2],8:21,9:7,11:8,12:9,13:10,14:[1,11],15:[1,12],16:[1,13],19:[1,19],20:[2,2],22:[1,14],23:[1,15],25:[1,16]},{17:23,21:24,29:25,36:[1,28],38:[1,27],39:26},{5:[2,4],7:38,8:6,9:7,11:8,12:9,13:10,14:[1,11],15:[1,12],16:[1,13],19:[1,19],20:[2,4],22:[1,14],23:[1,15],25:[1,16]},{5:[2,9],14:[2,9],15:[2,9],16:[2,9],19:[2,9],20:[2,9],22:[2,9],23:[2,9],25:[2,9]},{5:[2,23],14:[2,23],15:[2,23],16:[2,23],19:[2,23],20:[2,23],22:[2,23],23:[2,23],25:[2,23]},{18:[1,39]},{18:[2,27],21:44,24:[2,27],27:40,28:41,29:48,30:42,31:[1,45],32:[1,46],33:[1,47],34:43,35:49,36:[1,50],38:[1,27],39:26},{18:[2,28],24:[2,28]},{18:[2,48],24:[2,48],31:[2,48],32:[2,48],33:[2,48],36:[2,48],38:[2,48],40:[1,51]},{21:52,36:[1,28],39:26},{18:[2,50],24:[2,50],31:[2,50],32:[2,50],33:[2,50],36:[2,50],38:[2,50],40:[2,50]},{10:53,20:[1,54]},{10:55,20:[1,54]},{18:[1,56]},{18:[1,57]},{24:[1,58]},{18:[1,59],21:60,36:[1,28],39:26},{18:[2,44],36:[2,44]},{18:[2,45],36:[2,45]},{18:[2,46],36:[2,46]},{5:[2,3],8:21,9:7,11:8,12:9,13:10,14:[1,11],15:[1,12],16:[1,13],19:[1,19],20:[2,3],22:[1,14],23:[1,15],25:[1,16]},{14:[2,17],15:[2,17],16:[2,17],19:[2,17],20:[2,17],22:[2,17],23:[2,17],25:[2,17]},{18:[2,25],21:44,24:[2,25],28:61,29:48,30:62,31:[1,45],32:[1,46],33:[1,47],34:43,35:49,36:[1,50],38:[1,27],39:26},{18:[2,26],24:[2,26]},{18:[2,30],24:[2,30],31:[2,30],32:[2,30],33:[2,30],36:[2,30],38:[2,30]},{18:[2,36],24:[2,36],35:63,36:[1,64]},{18:[2,31],24:[2,31],31:[2,31],32:[2,31],33:[2,31],36:[2,31],38:[2,31]},{18:[2,32],24:[2,32],31:[2,32],32:[2,32],33:[2,32],36:[2,32],38:[2,32]},{18:[2,33],24:[2,33],31:[2,33],32:[2,33],33:[2,33],36:[2,33],38:[2,33]},{18:[2,34],24:[2,34],31:[2,34],32:[2,34],33:[2,34],36:[2,34],38:[2,34]},{18:[2,35],24:[2,35],31:[2,35],32:[2,35],33:[2,35],36:[2,35],38:[2,35]},{18:[2,38],24:[2,38],36:[2,38]},{18:[2,50],24:[2,50],31:[2,50],32:[2,50],33:[2,50],36:[2,50],37:[1,65],38:[2,50],40:[2,50]},{36:[1,66]},{18:[2,47],24:[2,47],31:[2,47],32:[2,47],33:[2,47],36:[2,47],38:[2,47]},{5:[2,10],14:[2,10],15:[2,10],16:[2,10],19:[2,10],20:[2,10],22:[2,10],23:[2,10],25:[2,10]},{21:67,36:[1,28],39:26},{5:[2,11],14:[2,11],15:[2,11],16:[2,11],19:[2,11],20:[2,11],22:[2,11],23:[2,11],25:[2,11]},{14:[2,16],15:[2,16],16:[2,16],19:[2,16],20:[2,16],22:[2,16],23:[2,16],25:[2,16]},{5:[2,19],14:[2,19],15:[2,19],16:[2,19],19:[2,19],20:[2,19],22:[2,19],23:[2,19],25:[2,19]},{5:[2,20],14:[2,20],15:[2,20],16:[2,20],19:[2,20],20:[2,20],22:[2,20],23:[2,20],25:[2,20]},{5:[2,21],14:[2,21],15:[2,21],16:[2,21],19:[2,21],20:[2,21],22:[2,21],23:[2,21],25:[2,21]},{18:[1,68]},{18:[2,24],24:[2,24]},{18:[2,29],24:[2,29],31:[2,29],32:[2,29],33:[2,29],36:[2,29],38:[2,29]},{18:[2,37],24:[2,37],36:[2,37]},{37:[1,65]},{21:69,29:73,31:[1,70],32:[1,71],33:[1,72],36:[1,28],38:[1,27],39:26},{18:[2,49],24:[2,49],31:[2,49],32:[2,49],33:[2,49],36:[2,49],38:[2,49],40:[2,49]},{18:[1,74]},{5:[2,22],14:[2,22],15:[2,22],16:[2,22],19:[2,22],20:[2,22],22:[2,22],23:[2,22],25:[2,22]},{18:[2,39],24:[2,39],36:[2,39]},{18:[2,40],24:[2,40],36:[2,40]},{18:[2,41],24:[2,41],36:[2,41]},{18:[2,42],24:[2,42],36:[2,42]},{18:[2,43],24:[2,43],36:[2,43]},{5:[2,18],14:[2,18],15:[2,18],16:[2,18],19:[2,18],20:[2,18],22:[2,18],23:[2,18],25:[2,18]}],
-defaultActions: {17:[2,1]},
+table: [{3:1,4:2,5:[2,7],6:3,7:4,8:6,9:7,11:8,12:9,13:10,14:[1,11],15:[1,12],16:[1,13],19:[1,5],22:[1,14],23:[1,15],24:[1,16]},{1:[3]},{5:[1,17]},{5:[2,6],7:18,8:6,9:7,11:8,12:9,13:10,14:[1,11],15:[1,12],16:[1,13],19:[1,19],20:[2,6],22:[1,14],23:[1,15],24:[1,16]},{5:[2,5],6:20,8:21,9:7,11:8,12:9,13:10,14:[1,11],15:[1,12],16:[1,13],19:[1,5],20:[2,5],22:[1,14],23:[1,15],24:[1,16]},{17:23,18:[1,22],21:24,28:[1,25],35:[1,27],38:26},{5:[2,8],14:[2,8],15:[2,8],16:[2,8],19:[2,8],20:[2,8],22:[2,8],23:[2,8],24:[2,8]},{4:28,6:3,7:4,8:6,9:7,11:8,12:9,13:10,14:[1,11],15:[1,12],16:[1,13],19:[1,5],20:[2,7],22:[1,14],23:[1,15],24:[1,16]},{4:29,6:3,7:4,8:6,9:7,11:8,12:9,13:10,14:[1,11],15:[1,12],16:[1,13],19:[1,5],20:[2,7],22:[1,14],23:[1,15],24:[1,16]},{5:[2,12],14:[2,12],15:[2,12],16:[2,12],19:[2,12],20:[2,12],22:[2,12],23:[2,12],24:[2,12]},{5:[2,13],14:[2,13],15:[2,13],16:[2,13],19:[2,13],20:[2,13],22:[2,13],23:[2,13],24:[2,13]},{5:[2,14],14:[2,14],15:[2,14],16:[2,14],19:[2,14],20:[2,14],22:[2,14],23:[2,14],24:[2,14]},{5:[2,15],14:[2,15],15:[2,15],16:[2,15],19:[2,15],20:[2,15],22:[2,15],23:[2,15],24:[2,15]},{17:30,21:24,28:[1,25],35:[1,27],38:26},{17:31,21:24,28:[1,25],35:[1,27],38:26},{17:32,21:24,28:[1,25],35:[1,27],38:26},{25:33,37:[1,34]},{1:[2,1]},{5:[2,2],8:21,9:7,11:8,12:9,13:10,14:[1,11],15:[1,12],16:[1,13],19:[1,19],20:[2,2],22:[1,14],23:[1,15],24:[1,16]},{17:23,21:24,28:[1,25],35:[1,27],38:26},{5:[2,4],7:35,8:6,9:7,11:8,12:9,13:10,14:[1,11],15:[1,12],16:[1,13],19:[1,19],20:[2,4],22:[1,14],23:[1,15],24:[1,16]},{5:[2,9],14:[2,9],15:[2,9],16:[2,9],19:[2,9],20:[2,9],22:[2,9],23:[2,9],24:[2,9]},{5:[2,23],14:[2,23],15:[2,23],16:[2,23],19:[2,23],20:[2,23],22:[2,23],23:[2,23],24:[2,23]},{18:[1,36]},{18:[2,27],21:41,26:37,27:38,28:[1,45],29:39,30:[1,42],31:[1,43],32:[1,44],33:40,34:46,35:[1,47],38:26},{18:[2,28]},{18:[2,45],28:[2,45],30:[2,45],31:[2,45],32:[2,45],35:[2,45],39:[1,48]},{18:[2,47],28:[2,47],30:[2,47],31:[2,47],32:[2,47],35:[2,47],39:[2,47]},{10:49,20:[1,50]},{10:51,20:[1,50]},{18:[1,52]},{18:[1,53]},{18:[1,54]},{18:[1,55],21:56,35:[1,27],38:26},{18:[2,44],35:[2,44]},{5:[2,3],8:21,9:7,11:8,12:9,13:10,14:[1,11],15:[1,12],16:[1,13],19:[1,19],20:[2,3],22:[1,14],23:[1,15],24:[1,16]},{14:[2,17],15:[2,17],16:[2,17],19:[2,17],20:[2,17],22:[2,17],23:[2,17],24:[2,17]},{18:[2,25],21:41,27:57,28:[1,45],29:58,30:[1,42],31:[1,43],32:[1,44],33:40,34:46,35:[1,47],38:26},{18:[2,26]},{18:[2,30],28:[2,30],30:[2,30],31:[2,30],32:[2,30],35:[2,30]},{18:[2,36],34:59,35:[1,60]},{18:[2,31],28:[2,31],30:[2,31],31:[2,31],32:[2,31],35:[2,31]},{18:[2,32],28:[2,32],30:[2,32],31:[2,32],32:[2,32],35:[2,32]},{18:[2,33],28:[2,33],30:[2,33],31:[2,33],32:[2,33],35:[2,33]},{18:[2,34],28:[2,34],30:[2,34],31:[2,34],32:[2,34],35:[2,34]},{18:[2,35],28:[2,35],30:[2,35],31:[2,35],32:[2,35],35:[2,35]},{18:[2,38],35:[2,38]},{18:[2,47],28:[2,47],30:[2,47],31:[2,47],32:[2,47],35:[2,47],36:[1,61],39:[2,47]},{35:[1,62]},{5:[2,10],14:[2,10],15:[2,10],16:[2,10],19:[2,10],20:[2,10],22:[2,10],23:[2,10],24:[2,10]},{21:63,35:[1,27],38:26},{5:[2,11],14:[2,11],15:[2,11],16:[2,11],19:[2,11],20:[2,11],22:[2,11],23:[2,11],24:[2,11]},{14:[2,16],15:[2,16],16:[2,16],19:[2,16],20:[2,16],22:[2,16],23:[2,16],24:[2,16]},{5:[2,19],14:[2,19],15:[2,19],16:[2,19],19:[2,19],20:[2,19],22:[2,19],23:[2,19],24:[2,19]},{5:[2,20],14:[2,20],15:[2,20],16:[2,20],19:[2,20],20:[2,20],22:[2,20],23:[2,20],24:[2,20]},{5:[2,21],14:[2,21],15:[2,21],16:[2,21],19:[2,21],20:[2,21],22:[2,21],23:[2,21],24:[2,21]},{18:[1,64]},{18:[2,24]},{18:[2,29],28:[2,29],30:[2,29],31:[2,29],32:[2,29],35:[2,29]},{18:[2,37],35:[2,37]},{36:[1,61]},{21:65,28:[1,69],30:[1,66],31:[1,67],32:[1,68],35:[1,27],38:26},{18:[2,46],28:[2,46],30:[2,46],31:[2,46],32:[2,46],35:[2,46],39:[2,46]},{18:[1,70]},{5:[2,22],14:[2,22],15:[2,22],16:[2,22],19:[2,22],20:[2,22],22:[2,22],23:[2,22],24:[2,22]},{18:[2,39],35:[2,39]},{18:[2,40],35:[2,40]},{18:[2,41],35:[2,41]},{18:[2,42],35:[2,42]},{18:[2,43],35:[2,43]},{5:[2,18],14:[2,18],15:[2,18],16:[2,18],19:[2,18],20:[2,18],22:[2,18],23:[2,18],24:[2,18]}],
+defaultActions: {17:[2,1],25:[2,28],38:[2,26],57:[2,24]},
 parseError: function parseError(str, hash) {
     throw new Error(str);
 },
@@ -600,7 +584,7 @@ case 3:
 break;
 case 4: yy_.yytext = yy_.yytext.substr(0, yy_.yyleng-4); this.popState(); return 15; 
 break;
-case 5: return 25; 
+case 5: this.begin("par"); return 24; 
 break;
 case 6: return 16; 
 break;
@@ -612,7 +596,7 @@ case 9: return 19;
 break;
 case 10: return 23; 
 break;
-case 11: return 22; 
+case 11: return 23; 
 break;
 case 12: this.popState(); this.begin('com'); 
 break;
@@ -620,44 +604,48 @@ case 13: yy_.yytext = yy_.yytext.substr(3,yy_.yyleng-5); this.popState(); return
 break;
 case 14: return 22; 
 break;
-case 15: return 37; 
+case 15: return 36; 
 break;
-case 16: return 36; 
+case 16: return 35; 
 break;
-case 17: return 36; 
+case 17: return 35; 
 break;
-case 18: return 40; 
+case 18: return 39; 
 break;
 case 19: /*ignore whitespace*/ 
 break;
-case 20: this.popState(); return 24; 
+case 20: this.popState(); return 18; 
 break;
 case 21: this.popState(); return 18; 
 break;
-case 22: yy_.yytext = yy_.yytext.substr(1,yy_.yyleng-2).replace(/\\"/g,'"'); return 31; 
+case 22: yy_.yytext = yy_.yytext.substr(1,yy_.yyleng-2).replace(/\\"/g,'"'); return 30; 
 break;
-case 23: yy_.yytext = yy_.yytext.substr(1,yy_.yyleng-2).replace(/\\'/g,"'"); return 31; 
+case 23: yy_.yytext = yy_.yytext.substr(1,yy_.yyleng-2).replace(/\\'/g,"'"); return 30; 
 break;
-case 24: return 38; 
+case 24: yy_.yytext = yy_.yytext.substr(1); return 28; 
 break;
-case 25: return 33; 
+case 25: return 32; 
 break;
-case 26: return 33; 
+case 26: return 32; 
 break;
-case 27: return 32; 
+case 27: return 31; 
 break;
-case 28: return 36; 
+case 28: return 35; 
 break;
-case 29: yy_.yytext = yy_.yytext.substr(1, yy_.yyleng-2); return 36; 
+case 29: yy_.yytext = yy_.yytext.substr(1, yy_.yyleng-2); return 35; 
 break;
 case 30: return 'INVALID'; 
 break;
-case 31: return 5; 
+case 31: /*ignore whitespace*/ 
+break;
+case 32: this.popState(); return 37; 
+break;
+case 33: return 5; 
 break;
 }
 };
-lexer.rules = [/^(?:\\\\(?=(\{\{)))/,/^(?:[^\x00]*?(?=(\{\{)))/,/^(?:[^\x00]+)/,/^(?:[^\x00]{2,}?(?=(\{\{|$)))/,/^(?:[\s\S]*?--\}\})/,/^(?:\{\{>)/,/^(?:\{\{#)/,/^(?:\{\{\/)/,/^(?:\{\{\^)/,/^(?:\{\{\s*else\b)/,/^(?:\{\{\{)/,/^(?:\{\{&)/,/^(?:\{\{!--)/,/^(?:\{\{![\s\S]*?\}\})/,/^(?:\{\{)/,/^(?:=)/,/^(?:\.(?=[}\/ ]))/,/^(?:\.\.)/,/^(?:[\/.])/,/^(?:\s+)/,/^(?:\}\}\})/,/^(?:\}\})/,/^(?:"(\\["]|[^"])*")/,/^(?:'(\\[']|[^'])*')/,/^(?:@)/,/^(?:true(?=[}\s]))/,/^(?:false(?=[}\s]))/,/^(?:-?[0-9]+(?=[}\s]))/,/^(?:[^\s!"#%-,\.\/;->@\[-\^`\{-~]+(?=[=}\s\/.]))/,/^(?:\[[^\]]*\])/,/^(?:.)/,/^(?:$)/];
-lexer.conditions = {"mu":{"rules":[5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31],"inclusive":false},"emu":{"rules":[3],"inclusive":false},"com":{"rules":[4],"inclusive":false},"INITIAL":{"rules":[0,1,2,31],"inclusive":true}};
+lexer.rules = [/^(?:\\\\(?=(\{\{)))/,/^(?:[^\x00]*?(?=(\{\{)))/,/^(?:[^\x00]+)/,/^(?:[^\x00]{2,}?(?=(\{\{|$)))/,/^(?:[\s\S]*?--\}\})/,/^(?:\{\{>)/,/^(?:\{\{#)/,/^(?:\{\{\/)/,/^(?:\{\{\^)/,/^(?:\{\{\s*else\b)/,/^(?:\{\{\{)/,/^(?:\{\{&)/,/^(?:\{\{!--)/,/^(?:\{\{![\s\S]*?\}\})/,/^(?:\{\{)/,/^(?:=)/,/^(?:\.(?=[}/ ]))/,/^(?:\.\.)/,/^(?:[\/.])/,/^(?:\s+)/,/^(?:\}\}\})/,/^(?:\}\})/,/^(?:"(\\["]|[^"])*")/,/^(?:'(\\[']|[^'])*')/,/^(?:@[a-zA-Z]+)/,/^(?:true(?=[}\s]))/,/^(?:false(?=[}\s]))/,/^(?:-?[0-9]+(?=[}\s]))/,/^(?:[a-zA-Z0-9_$:\-]+(?=[=}\s\/.]))/,/^(?:\[[^\]]*\])/,/^(?:.)/,/^(?:\s+)/,/^(?:[a-zA-Z0-9_$\-\/]+)/,/^(?:$)/];
+lexer.conditions = {"mu":{"rules":[5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,33],"inclusive":false},"emu":{"rules":[3],"inclusive":false},"com":{"rules":[4],"inclusive":false},"par":{"rules":[31,32],"inclusive":false},"INITIAL":{"rules":[0,1,2,33],"inclusive":true}};
 return lexer;})()
 parser.lexer = lexer;
 function Parser () { this.yy = {}; }Parser.prototype = parser;parser.Parser = Parser;
@@ -743,24 +731,21 @@ Handlebars.AST.HashNode = function(pairs) {
 
 Handlebars.AST.IdNode = function(parts) {
   this.type = "ID";
+  this.original = parts.join(".");
 
-  var original = "",
-      dig = [],
-      depth = 0;
+  var dig = [], depth = 0;
 
   for(var i=0,l=parts.length; i<l; i++) {
-    var part = parts[i].part;
-    original += (parts[i].separator || '') + part;
+    var part = parts[i];
 
     if (part === ".." || part === "." || part === "this") {
-      if (dig.length > 0) { throw new Handlebars.Exception("Invalid path: " + original); }
+      if (dig.length > 0) { throw new Handlebars.Exception("Invalid path: " + this.original); }
       else if (part === "..") { depth++; }
       else { this.isScoped = true; }
     }
     else { dig.push(part); }
   }
 
-  this.original = original;
   this.parts    = dig;
   this.string   = dig.join('.');
   this.depth    = depth;
@@ -774,7 +759,7 @@ Handlebars.AST.IdNode = function(parts) {
 
 Handlebars.AST.PartialNameNode = function(name) {
   this.type = "PARTIAL_NAME";
-  this.name = name.original;
+  this.name = name;
 };
 
 Handlebars.AST.DataNode = function(id) {
@@ -784,15 +769,13 @@ Handlebars.AST.DataNode = function(id) {
 
 Handlebars.AST.StringNode = function(string) {
   this.type = "STRING";
-  this.original =
-    this.string =
-    this.stringModeValue = string;
+  this.string = string;
+  this.stringModeValue = string;
 };
 
 Handlebars.AST.IntegerNode = function(integer) {
   this.type = "INTEGER";
-  this.original =
-    this.integer = integer;
+  this.integer = integer;
   this.stringModeValue = Number(integer);
 };
 
@@ -1179,15 +1162,7 @@ Compiler.prototype = {
 
   DATA: function(data) {
     this.options.data = true;
-    if (data.id.isScoped || data.id.depth) {
-      throw new Handlebars.Exception('Scoped data references are not supported: ' + data.original);
-    }
-
-    this.opcode('lookupData');
-    var parts = data.id.parts;
-    for(var i=0, l=parts.length; i<l; i++) {
-      this.opcode('lookup', parts[i]);
-    }
+    this.opcode('lookupData', data.id);
   },
 
   STRING: function(string) {
@@ -1386,9 +1361,8 @@ JavaScriptCompiler.prototype = {
 
     if (!this.isChild) {
       var namespace = this.namespace;
-
-      var copies = "helpers = this.merge(helpers, " + namespace + ".helpers);";
-      if (this.environment.usePartial) { copies = copies + " partials = this.merge(partials, " + namespace + ".partials);"; }
+      var copies = "helpers = helpers || " + namespace + ".helpers;";
+      if (this.environment.usePartial) { copies = copies + " partials = partials || " + namespace + ".partials;"; }
       if (this.options.data) { copies = copies + " data = data || {};"; }
       out.push(copies);
     } else {
@@ -1417,9 +1391,7 @@ JavaScriptCompiler.prototype = {
     // Generate minimizer alias mappings
     if (!this.isChild) {
       for (var alias in this.context.aliases) {
-        if (this.context.aliases.hasOwnProperty(alias)) {
-          this.source[1] = this.source[1] + ', ' + alias + '=' + this.context.aliases[alias];
-        }
+        this.source[1] = this.source[1] + ', ' + alias + '=' + this.context.aliases[alias];
       }
     }
 
@@ -1638,7 +1610,7 @@ JavaScriptCompiler.prototype = {
   //
   // Push the result of looking up `id` on the current data
   lookupData: function(id) {
-    this.push('data');
+    this.push(this.nameLookup('data', id, 'data'));
   },
 
   // [pushStringParam]
@@ -1745,9 +1717,8 @@ JavaScriptCompiler.prototype = {
     this.context.aliases.helperMissing = 'helpers.helperMissing';
 
     var helper = this.lastHelper = this.setupHelper(paramSize, name, true);
-    var nonHelper = this.nameLookup('depth' + this.lastContext, name, 'context');
 
-    this.push(helper.name + ' || ' + nonHelper);
+    this.push(helper.name);
     this.replaceStack(function(name) {
       return name + ' ? ' + name + '.call(' +
           helper.callParams + ") " + ": helperMissing.call(" +
@@ -2191,16 +2162,6 @@ Handlebars.VM = {
           programWrapper = this.programs[i] = Handlebars.VM.program(i, fn);
         }
         return programWrapper;
-      },
-      merge: function(param, common) {
-        var ret = param || common;
-
-        if (param && common) {
-          ret = {};
-          Handlebars.Utils.extend(ret, common);
-          Handlebars.Utils.extend(ret, param);
-        }
-        return ret;
       },
       programWithDepth: Handlebars.VM.programWithDepth,
       noop: Handlebars.VM.noop,

--- a/vendor/handlebars/handlebars.runtime.js
+++ b/vendor/handlebars/handlebars.runtime.js
@@ -1,0 +1,345 @@
+/*
+
+Copyright (C) 2011 by Yehuda Katz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+*/
+
+// lib/handlebars/browser-prefix.js
+var Handlebars = {};
+
+(function(Handlebars, undefined) {
+;
+// lib/handlebars/base.js
+
+Handlebars.VERSION = "1.0.0-rc.4";
+Handlebars.COMPILER_REVISION = 3;
+
+Handlebars.REVISION_CHANGES = {
+  1: '<= 1.0.rc.2', // 1.0.rc.2 is actually rev2 but doesn't report it
+  2: '== 1.0.0-rc.3',
+  3: '>= 1.0.0-rc.4'
+};
+
+Handlebars.helpers  = {};
+Handlebars.partials = {};
+
+var toString = Object.prototype.toString,
+    functionType = '[object Function]',
+    objectType = '[object Object]';
+
+Handlebars.registerHelper = function(name, fn, inverse) {
+  if (toString.call(name) === objectType) {
+    if (inverse || fn) { throw new Handlebars.Exception('Arg not supported with multiple helpers'); }
+    Handlebars.Utils.extend(this.helpers, name);
+  } else {
+    if (inverse) { fn.not = inverse; }
+    this.helpers[name] = fn;
+  }
+};
+
+Handlebars.registerPartial = function(name, str) {
+  if (toString.call(name) === objectType) {
+    Handlebars.Utils.extend(this.partials,  name);
+  } else {
+    this.partials[name] = str;
+  }
+};
+
+Handlebars.registerHelper('helperMissing', function(arg) {
+  if(arguments.length === 2) {
+    return undefined;
+  } else {
+    throw new Error("Could not find property '" + arg + "'");
+  }
+});
+
+Handlebars.registerHelper('blockHelperMissing', function(context, options) {
+  var inverse = options.inverse || function() {}, fn = options.fn;
+
+  var type = toString.call(context);
+
+  if(type === functionType) { context = context.call(this); }
+
+  if(context === true) {
+    return fn(this);
+  } else if(context === false || context == null) {
+    return inverse(this);
+  } else if(type === "[object Array]") {
+    if(context.length > 0) {
+      return Handlebars.helpers.each(context, options);
+    } else {
+      return inverse(this);
+    }
+  } else {
+    return fn(context);
+  }
+});
+
+Handlebars.K = function() {};
+
+Handlebars.createFrame = Object.create || function(object) {
+  Handlebars.K.prototype = object;
+  var obj = new Handlebars.K();
+  Handlebars.K.prototype = null;
+  return obj;
+};
+
+Handlebars.logger = {
+  DEBUG: 0, INFO: 1, WARN: 2, ERROR: 3, level: 3,
+
+  methodMap: {0: 'debug', 1: 'info', 2: 'warn', 3: 'error'},
+
+  // can be overridden in the host environment
+  log: function(level, obj) {
+    if (Handlebars.logger.level <= level) {
+      var method = Handlebars.logger.methodMap[level];
+      if (typeof console !== 'undefined' && console[method]) {
+        console[method].call(console, obj);
+      }
+    }
+  }
+};
+
+Handlebars.log = function(level, obj) { Handlebars.logger.log(level, obj); };
+
+Handlebars.registerHelper('each', function(context, options) {
+  var fn = options.fn, inverse = options.inverse;
+  var i = 0, ret = "", data;
+
+  if (options.data) {
+    data = Handlebars.createFrame(options.data);
+  }
+
+  if(context && typeof context === 'object') {
+    if(context instanceof Array){
+      for(var j = context.length; i<j; i++) {
+        if (data) { data.index = i; }
+        ret = ret + fn(context[i], { data: data });
+      }
+    } else {
+      for(var key in context) {
+        if(context.hasOwnProperty(key)) {
+          if(data) { data.key = key; }
+          ret = ret + fn(context[key], {data: data});
+          i++;
+        }
+      }
+    }
+  }
+
+  if(i === 0){
+    ret = inverse(this);
+  }
+
+  return ret;
+});
+
+Handlebars.registerHelper('if', function(context, options) {
+  var type = toString.call(context);
+  if(type === functionType) { context = context.call(this); }
+
+  if(!context || Handlebars.Utils.isEmpty(context)) {
+    return options.inverse(this);
+  } else {
+    return options.fn(this);
+  }
+});
+
+Handlebars.registerHelper('unless', function(context, options) {
+  return Handlebars.helpers['if'].call(this, context, {fn: options.inverse, inverse: options.fn});
+});
+
+Handlebars.registerHelper('with', function(context, options) {
+  if (!Handlebars.Utils.isEmpty(context)) return options.fn(context);
+});
+
+Handlebars.registerHelper('log', function(context, options) {
+  var level = options.data && options.data.level != null ? parseInt(options.data.level, 10) : 1;
+  Handlebars.log(level, context);
+});
+;
+// lib/handlebars/utils.js
+
+var errorProps = ['description', 'fileName', 'lineNumber', 'message', 'name', 'number', 'stack'];
+
+Handlebars.Exception = function(message) {
+  var tmp = Error.prototype.constructor.apply(this, arguments);
+
+  // Unfortunately errors are not enumerable in Chrome (at least), so `for prop in tmp` doesn't work.
+  for (var idx = 0; idx < errorProps.length; idx++) {
+    this[errorProps[idx]] = tmp[errorProps[idx]];
+  }
+};
+Handlebars.Exception.prototype = new Error();
+
+// Build out our basic SafeString type
+Handlebars.SafeString = function(string) {
+  this.string = string;
+};
+Handlebars.SafeString.prototype.toString = function() {
+  return this.string.toString();
+};
+
+var escape = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#x27;",
+  "`": "&#x60;"
+};
+
+var badChars = /[&<>"'`]/g;
+var possible = /[&<>"'`]/;
+
+var escapeChar = function(chr) {
+  return escape[chr] || "&amp;";
+};
+
+Handlebars.Utils = {
+  extend: function(obj, value) {
+    for(var key in value) {
+      if(value.hasOwnProperty(key)) {
+        obj[key] = value[key];
+      }
+    }
+  },
+
+  escapeExpression: function(string) {
+    // don't escape SafeStrings, since they're already safe
+    if (string instanceof Handlebars.SafeString) {
+      return string.toString();
+    } else if (string == null || string === false) {
+      return "";
+    }
+
+    // Force a string conversion as this will be done by the append regardless and
+    // the regex test will do this transparently behind the scenes, causing issues if
+    // an object's to string has escaped characters in it.
+    string = string.toString();
+
+    if(!possible.test(string)) { return string; }
+    return string.replace(badChars, escapeChar);
+  },
+
+  isEmpty: function(value) {
+    if (!value && value !== 0) {
+      return true;
+    } else if(toString.call(value) === "[object Array]" && value.length === 0) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+};
+;
+// lib/handlebars/runtime.js
+
+Handlebars.VM = {
+  template: function(templateSpec) {
+    // Just add water
+    var container = {
+      escapeExpression: Handlebars.Utils.escapeExpression,
+      invokePartial: Handlebars.VM.invokePartial,
+      programs: [],
+      program: function(i, fn, data) {
+        var programWrapper = this.programs[i];
+        if(data) {
+          programWrapper = Handlebars.VM.program(i, fn, data);
+        } else if (!programWrapper) {
+          programWrapper = this.programs[i] = Handlebars.VM.program(i, fn);
+        }
+        return programWrapper;
+      },
+      programWithDepth: Handlebars.VM.programWithDepth,
+      noop: Handlebars.VM.noop,
+      compilerInfo: null
+    };
+
+    return function(context, options) {
+      options = options || {};
+      var result = templateSpec.call(container, Handlebars, context, options.helpers, options.partials, options.data);
+
+      var compilerInfo = container.compilerInfo || [],
+          compilerRevision = compilerInfo[0] || 1,
+          currentRevision = Handlebars.COMPILER_REVISION;
+
+      if (compilerRevision !== currentRevision) {
+        if (compilerRevision < currentRevision) {
+          var runtimeVersions = Handlebars.REVISION_CHANGES[currentRevision],
+              compilerVersions = Handlebars.REVISION_CHANGES[compilerRevision];
+          throw "Template was precompiled with an older version of Handlebars than the current runtime. "+
+                "Please update your precompiler to a newer version ("+runtimeVersions+") or downgrade your runtime to an older version ("+compilerVersions+").";
+        } else {
+          // Use the embedded version info since the runtime doesn't know about this revision yet
+          throw "Template was precompiled with a newer version of Handlebars than the current runtime. "+
+                "Please update your runtime to a newer version ("+compilerInfo[1]+").";
+        }
+      }
+
+      return result;
+    };
+  },
+
+  programWithDepth: function(i, fn, data /*, $depth */) {
+    var args = Array.prototype.slice.call(arguments, 3);
+
+    var program = function(context, options) {
+      options = options || {};
+
+      return fn.apply(this, [context, options.data || data].concat(args));
+    };
+    program.program = i;
+    program.depth = args.length;
+    return program;
+  },
+  program: function(i, fn, data) {
+    var program = function(context, options) {
+      options = options || {};
+
+      return fn(context, options.data || data);
+    };
+    program.program = i;
+    program.depth = 0;
+    return program;
+  },
+  noop: function() { return ""; },
+  invokePartial: function(partial, name, context, helpers, partials, data) {
+    var options = { helpers: helpers, partials: partials, data: data };
+
+    if(partial === undefined) {
+      throw new Handlebars.Exception("The partial " + name + " could not be found");
+    } else if(partial instanceof Function) {
+      return partial(context, options);
+    } else if (!Handlebars.compile) {
+      throw new Handlebars.Exception("The partial " + name + " could not be compiled when running in runtime-only mode");
+    } else {
+      partials[name] = Handlebars.compile(partial, {data: data !== undefined});
+      return partials[name](context, options);
+    }
+  }
+};
+
+Handlebars.template = Handlebars.VM.template;
+;
+// lib/handlebars/browser-suffix.js
+})(Handlebars);
+;


### PR DESCRIPTION
Pull request #54 changed the bower config to use Ember 1.0.0-rc.6
(because the [components/ember](https://github.com/components/ember)
repo isn't updated for 1.0.0-rc.6.1 yet), but it did not update the
vendored version of ember.

Pull request #37 changed `public/index.html` to use `handlebars.js`
instead of using the runtime component (`handlebars.runtime.js`) because
the runtime component wasn't explicitly added to the repo as part of #26.
This PR adds `handlebars.runtime.js` back into this repo, and reverts
the changes from #37 (meaning that we now use the runtime only). This
should resolve #40.

The required version of `grunt-ember-templates` was changed to `0.4.10` in
0d00bacf86c92e7a24b036ea788c2ad03d41e363, but since `ember-1.0.0-rc.6`
can't use `handlebars-1.0.0` we must hard code our dependency to
`grunt-ember-templates-0.4.9` (which uses `handlebars-1.0.0-rc.4`).

To recap:
- Reset our vendored files to `ember-1.0.0-rc6`, `handlebars-1.0.0-rc.4`,
  `grunt-ember-templates-0.4.9`.
- Update `public/index.html` and `tests/index.html` to use
  `handlebars.runtime.js`.
- Should resolve #40.
