### PR TITLE
remove vendorCss configuration and its usage in tests + public index.htm...

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,8 +2,6 @@
 <html>
 <head>
   <title>App</title>
-
-  <link rel="stylesheet" href="assets/vendor.css">
   <link rel="stylesheet" href="assets/app.css">
 
   <!-- for more details visit: https://github.com/yeoman/grunt-usemin -->

--- a/tasks/options/concat.js
+++ b/tasks/options/concat.js
@@ -7,10 +7,5 @@ module.exports = {
   test: {
     src: 'tmp/transpiled/tests/**/*.js',
     dest: 'tmp/public/tests/tests.js'
-  },
-
-  vendorCss: {
-    src: ['vendor/**/*.css'],
-    dest: 'tmp/public/assets/vendor.css'
   }
 };

--- a/tests/index.html
+++ b/tests/index.html
@@ -2,7 +2,6 @@
 <html>
 <head>
   <title>App Kit</title>
-  <link rel="stylesheet" href="/assets/vendor.css" media="all">
   <link rel="stylesheet" href="/assets/app.css"    media="all">
   <link rel="stylesheet" href="/vendor/qunit/qunit/qunit.css"   media="all">
   <style>


### PR DESCRIPTION
assets/vendor.css(and the concat task that created it) is not needed anymore by default due to @rjackson pulling qunit via bower(the only code to use it). 

AKA, before this, tests/index.html was loading the css for qunit twice(/vendor/qunit/qunit/qunit.css & assets/vendor.css) and furthermore, public/index.html was loading qunit css once(which never made sense anyway).
