### PR TITLE
Update grunt-ember-templates to v0.4.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "grunt-usemin": "~0.1.12",
     "grunt-contrib-uglify": "~0.2.2",
     "grunt-rev": "~0.1.0",
-    "grunt-ember-templates": "~>0.4.10",
+    "grunt-ember-templates": "~>0.4.12",
     "string": "~1.4.0",
     "karma": "~0.9.4",
     "grunt-karma": "~0.5",

--- a/tasks/options/ember_templates.js
+++ b/tasks/options/ember_templates.js
@@ -1,9 +1,8 @@
 module.exports = {
   compile: {
     options: {
-      templateName: function(filename) {
-        return filename.replace(/app\/templates\//,'').replace(/\.(hbs|hjs|handlebars)/,'');
-      }
+      templateBasePath: /app\/templates\//,
+      templateFileExtensions: /\.(hbs|hjs|handlebars)/
     },
     files: {
       "tmp/public/assets/templates.js": "app/templates/**/*.{hbs,hjs,handlebars}"


### PR DESCRIPTION
Uses v1.0.0-rc.7 of ember-template-compiler.js, and new `templateBasePath` and `templateFileExtensions` options.
