### PR TITLE
Add structure to use test helpers.

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,9 +15,9 @@ module.exports = function(config) {
       'vendor/ember/index.js',
       'assets/templates.js',
       'assets/app.js',
-      'tests/test_helper.js',
       'tests/tests.js',
-      'tests/test_loader.js'
+      'tests/test_loader.js',
+      'tests/test_helper.js',
     ],
 
     frameworks: ['qunit'],

--- a/tests/helpers/controller_for.js
+++ b/tests/helpers/controller_for.js
@@ -1,0 +1,3 @@
+Ember.Test.registerHelper('controllerFor', function(app, controllerName) {
+  return app.__container__.lookup('controller:' + controllerName);
+});

--- a/tests/helpers/route_for.js
+++ b/tests/helpers/route_for.js
@@ -1,0 +1,3 @@
+Ember.Test.registerHelper('routeFor', function(app, routeName) {
+  return app.__container__.lookup('route:' + routeName);
+});

--- a/tests/index.html
+++ b/tests/index.html
@@ -34,8 +34,8 @@
 <body>
   <div id="qunit"></div>
   <div id="qunit-fixture"></div>
-  <script src="/tests/test_helper.js"></script>
   <script src="/tests/tests.js"></script>
   <script src="/tests/test_loader.js"></script>
+  <script src="/tests/test_helper.js"></script>
 </body>
 </html>

--- a/tests/test_loader.js
+++ b/tests/test_loader.js
@@ -1,4 +1,4 @@
 // TODO: load based on params
 Ember.keys(define.registry).filter(function(key) {
-  return (/\_test/).test(key);
+  return (/\_test/).test(key) || (/tests\/helpers/).test(key);
 }).forEach(requireModule);

--- a/tests/unit/routes/index_test.js
+++ b/tests/unit/routes/index_test.js
@@ -5,7 +5,7 @@ var route;
 
 module("Unit - IndexRoute", {
   setup: function(){
-    route = App.__container__.lookup('route:index');
+    route = routeFor('index');
   }
 });
 


### PR DESCRIPTION
This PR adds `routeFor` and `controllerFor` helpers.  

In using EAK in a project I found that I often repeat the `App.__container__.lookup('type:name');` setup stuff all over the place in my unit tests, and thought it may be useful to have a couple of small helpers for this. 

I also thought that it would be useful to have an established structure for how to include new test helpers.
