### PR TITLE
remove unused string require in gruntfile

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -62,7 +62,6 @@ module.exports = function(grunt) {
 
 // TODO: extract this out
 function loadConfig(path) {
-  var string = require('string');
   var glob = require('glob');
   var object = {};
   var key;


### PR DESCRIPTION
There is a random `var string = require('string')` in the Gruntfile that doesn't look like it is being used. I took it out and ran some grunt tasks and they all seemed to work still.
