### PR TITLE
Better wildcard fall-through for assets

### DIFF
--- a/tasks/options/connect.js
+++ b/tasks/options/connect.js
@@ -35,9 +35,18 @@ function lock(req, res, next) {
   }());
 }
 
+function wildcardResponseIsValid(request) {
+  var urlSegments = request.url.split('.'),
+      extension   = urlSegments[urlSegments.length-1];
+  return (
+    ['GET', 'HEAD'].indexOf(request.method.toUpperCase()) > -1 &&
+    (urlSegments.length == 1 || extension.indexOf('htm') == 0 || extension.length > 5)
+  )
+}
+
 function buildWildcardMiddleware(options) {
-  return function(req, res, next) {
-    if ('GET' != req.method.toUpperCase() && 'HEAD' != req.method.toUpperCase()) { return next();  }
+  return function(request, response, next) {
+    if (!wildcardResponseIsValid(request)) { return next(); }
 
     var wildcard     = (options.wildcard || 'index.html'),
         wildcardPath = options.base + "/" + wildcard;
@@ -45,8 +54,8 @@ function buildWildcardMiddleware(options) {
     fs.readFile(wildcardPath, function(err, data){
       if (err) { return next('ENOENT' == err.code ? null : err); }
 
-      res.writeHead(200, { 'Content-Type': 'text/html' });
-      res.end(data);
+      response.writeHead(200, { 'Content-Type': 'text/html' });
+      response.end(data);
     });
   }
 }


### PR DESCRIPTION
Only serve the wildcard if:
- GET or HEAD is being called.
- There are no "." characters in the URL, OR the url extension starts
  with "htm", OR the url extension is over 5 chars long.

This will cause JavaScript and other assets to fail with 404 errors as normally expected.

Ref:
https://github.com/stefanpenner/ember-app-kit/commit/02882c7da3e3745606c595ea5566b52bff7567a2#commitcomment-3963307
