### PR TITLE
Ignore ALL .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,4 @@
 /.sass-cache
 /connect.lock
 /libpeerconnection.log
-.DS_Store
+**/.DS_Store


### PR DESCRIPTION
This is very useful in case someone opens another folder, eg. app/images, in Finder.
