### PR TITLE
Clean out 'dist' directory upon building for release.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,6 +37,7 @@ module.exports = function(grunt) {
 
   grunt.registerTask('build:dist', "Build a minified & production-ready version of your app.", [
                      'build',
+                     'clean:release',
                      'dom_munger:distDependencies',
                      'useminPrepare',
                      'concat',


### PR DESCRIPTION
Added task to 'build:dist' to clean out the 'dist' (release) directory on build.

Fixes #104 
