### PR TITLE
Added wildcard to the git ignore rule for vendor.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 
 # dependencies
 /node_modules
-/vendor
+/vendor/*
 !/vendor/loader.js
 
 # misc


### PR DESCRIPTION
When cloning the the repository, the initial commit will not contain the vendor folder and its loader.js file.  This fix will allow those two files to be initially committed.
