### PR TITLE
Added wildcard to vendor dir in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 
 # dependencies
 /node_modules
-/vendor
+/vendor/*
 !/vendor/loader.js
 
 # misc


### PR DESCRIPTION
When cloning the project and performing an initial commit the current `.gitignore` rules prevent the `loader.js` file from being committed.  I noticed this issue when Travis CI was bombing on builds.

Thanks again for creating this project.  It really has taught me a lot about JavaScript project organization.  Also, congrats on Ember 1.0!
