### PR TITLE
replace '.' with '/' globaly in moduleName

### DIFF
--- a/vendor/loader.js
+++ b/vendor/loader.js
@@ -94,7 +94,7 @@ define("resolver",
     var pluralizedType = parsedName.type + 's';
     var name = parsedName.fullNameWithoutType;
 
-    var moduleName = prefix + '/' +  pluralizedType + '/' + name.replace(/\./g, '/');
+    var moduleName = prefix + '/' +  pluralizedType + '/' + name;
     var module;
 
     if (define.registry[moduleName]) {
@@ -128,7 +128,7 @@ define("resolver",
       // 1. `needs: ['posts/post']`
       // 2. `{{render "posts/post"}}`
       // 3. `this.render('posts/post')` from Route
-      return fullName.replace(/\./, '/');
+      return fullName.replace(/\./g, '/');
     }
   });
 


### PR DESCRIPTION
This fixes a small bug in the resolver::resolveOther method, that prevents deeply nested directory structures to be resolved correctly.
