### PR TITLE
Templates not precompiled for tests, don't use handlebar's runtime only

### DIFF
--- a/tests/index.html
+++ b/tests/index.html
@@ -22,7 +22,7 @@
   </style>
 
   <script src="/vendor/jquery/jquery.js"></script>
-  <script src="/vendor/handlebars/handlebars.runtime.js"></script>
+  <script src="/vendor/handlebars/handlebars.js"></script>
   <script src="/vendor/ember/index.js"></script>
   <script src="/vendor/loader.js"></script>
 


### PR DESCRIPTION
Application tests were not running without this change.
