### PR TITLE
add emblem.js option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,6 @@
 
 # dependencies
 /node_modules
-/vendor/*
-!/vendor/loader.js
 
 # misc
 /.sass-cache

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,6 +21,13 @@ module.exports = function(grunt) {
                      'transpile',
                      'jshint',
                      'copy:stage',
+                     //For emblem.js:
+                     //1. run 'npm install --save-dev grunt-emblem`
+                     //2. Install emblem.js in vendor dir (available at https://github.com/machty/emblem.js)
+                     //3. Refer to dir you installed emblem.js in tasks/options/emblem.js dependencies section
+                     //4. Remove emberTemplates lines in build:debug and build:dist tasks
+                     //5. uncomment line below
+                     //'emblem:compile',
                      // Uncomment line below & `npm install --save-dev grunt-sass` for SASS (SCSS only) support.
                      // or run `npm install --save-dev grunt-contrib-sass` for SCSS/SASS support (may be slower).
                      // 'sass:compile',

--- a/tasks/options/emblem.js
+++ b/tasks/options/emblem.js
@@ -1,0 +1,17 @@
+module.exports = {
+  compile: {
+    files: {
+      "tmp/public/assets/templates.js": ['app/templates/**/*.{emblem,hbs,hjs,handlebars}']
+    },
+    options: {
+      root: 'app/templates/',
+      dependencies: {
+        jquery: 'vendor/jquery/jquery.js',
+        ember: 'vendor/ember/index.js',
+        handlebars: 'vendor/handlebars/handlebars.js',
+        //specify where you put emblem.js here
+        emblem: 'vendor/handlebars/emblem.js'
+      }
+    }
+  }
+};


### PR DESCRIPTION
If too much text for the gruntfile, alternatively we could put those instructions in the readme or other help file.

The .gitignore change could also be undone, and instead have an instruction to leave the emblem.js file out of the .gitignore, but seems may want to add other js files here or track updates to those already there?
