### PR TITLE
Fix typeof-array-check

### DIFF
--- a/tasks/helpers.js
+++ b/tasks/helpers.js
@@ -27,7 +27,7 @@ Helpers.whenTaskIsAvailable = function(taskName) {
 };
 
 Helpers.isPackageAvailable = function(pkgNames) {
-  if ('array' !== typeof pkgNames) {
+  if (!_.isArray(pkgNames)) {
     pkgNames = [pkgNames];
   }
   return _.every(pkgNames, function(pkgName){


### PR DESCRIPTION
Using Lo-Dash' `isArray` function to check for `array` objects as `typeof []` gives just 'object'.
