### PR TITLE
grunt task cleanup

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -68,7 +68,6 @@ module.exports = function(grunt) {
                      'copy:prepare',
                      'transpile',
                      'jshint',
-                     'copy:stage',
                      'concat_sourcemap'
                      ]));
 
@@ -77,9 +76,7 @@ module.exports = function(grunt) {
                      'sass:compile',
                      'less:compile',
                      'stylus:compile',
-                     'cssmin',
-                     'concat_sourcemap',
-                     'unlock'
+                     'cssmin'
                      ]));
 
   grunt.registerTask('build:other', filterAvailable([


### PR DESCRIPTION
- Remove `copy:stage` and `unlock` from other targets, since it will be called in `build:after` and `build:after:debug`
- Remove `concat_sourcemap` from `build:styles`
