### PR TITLE
Update CoffeeScript docs to use the current ES6 syntax

### DIFF
--- a/tasks/options/coffee.js
+++ b/tasks/options/coffee.js
@@ -5,13 +5,13 @@
 // anyway. In CoffeeScript files, you need to escape out for
 // some ES6 features like import and export. For example:
 //
-// `import 'appkit/models/user' as User`
+// `import User from 'appkit/models/user'`
 //
-// Posts = Em.Object.extend
+// Post = Em.Object.extend
 //   init: (userId) ->
 //     @set 'user', User.findById(userId)
 //
-// `export = Posts`
+// `export default Post`
 //
 
 module.exports = {


### PR DESCRIPTION
Updates the CoffeeScript example to use the latest ES6 syntax.
