### PR TITLE
Fix arrays of requirements [fixes #152]

### DIFF
--- a/tasks/helpers.js
+++ b/tasks/helpers.js
@@ -42,7 +42,7 @@ Helpers.isPackageAvailable = function(pkgNames) {
   if (!_.isArray(pkgNames)) {
     pkgNames = [pkgNames];
   }
-  return _.every(pkgNames, function(pkgName){
+  return _.any(pkgNames, function(pkgName){
     return !!Helpers.config.pkg.devDependencies[pkgName];
   });
 };


### PR DESCRIPTION
If I set a requirement for Sass like:

``` javascript
var requirements = {
  'sass': ['grunt-sass', 'grunt-contrib-sass']
}
```

`isPackageAvailable` will return false if I only have `grunt-contrib-sass` installed, which is the most likely case. This provides the fix for #152.
