### PR TITLE
copy:stage before building

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -61,11 +61,13 @@ module.exports = function(grunt) {
   grunt.registerTask('build:before:dist', [
                      'clean:build',
                      'clean:release',
+                     'copy:stage',
                      'lock'
                      ]);
 
   grunt.registerTask('build:before:debug', [
                      'clean:build',
+                     'copy:stage',
                      'lock'
                      ]);
 
@@ -100,7 +102,6 @@ module.exports = function(grunt) {
                      ]));
 
   grunt.registerTask('build:after:dist', filterAvailable([
-                     'copy:stage',
                      'unlock',
                      'dom_munger:distEmber',
                      'dom_munger:distHandlebars',
@@ -113,8 +114,7 @@ module.exports = function(grunt) {
                      ]));
 
   grunt.registerTask('build:after:debug', filterAvailable([
-                     'copy:stage',
-                     'unlock' 
+                     'unlock'
                      ]));
 
   grunt.registerTask('build:dist', "Build a minified & production-ready version of your app.", [


### PR DESCRIPTION
I didn't commit this to master because I just rolled out of bed and I need a sanity check.

This would fix [this issue](https://github.com/stefanpenner/ember-app-kit/pull/157#issuecomment-24588104) and makes sure that compiled output is never overwritten by `public/assets`.
