### PR TITLE
Preceeding slash for the app.css link tag.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <title>App</title>
-  <link rel="stylesheet" href="assets/app.css">
+  <link rel="stylesheet" href="/assets/app.css">
 
   <!-- for more details visit: https://github.com/yeoman/grunt-usemin -->
 


### PR DESCRIPTION
Required in order to avoid relative paths which breaks URLs with multiple segments.

Fixes #160
