### PR TITLE
start giving a more 'Ember-like' appearance

### DIFF
--- a/assets/styles/slate.css
+++ b/assets/styles/slate.css
@@ -54,10 +54,10 @@ Theme Styles
 
 body {
   box-sizing: border-box;
-  color:#373737;
+  color: #444444;
   background: #212121;
   font-size: 16px;
-  font-family: 'Myriad Pro', Calibri, Helvetica, Arial, sans-serif;
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
 }
@@ -65,8 +65,8 @@ body {
 h1, h2, h3, h4, h5, h6 {
   margin: 10px 0;
   font-weight: 700;
-  color:#222222;
-  font-family: 'Lucida Grande', 'Calibri', Helvetica, Arial, sans-serif;
+  color: #e1563f;
+  font-family: 'Maven Pro', Helvetica, Arial, sans-serif;
   letter-spacing: -1px;
 }
 
@@ -107,7 +107,7 @@ footer p {
 
 a {
   text-decoration: none;
-  color: #007edf;
+  color: #f23818;
   text-shadow: none;
 
   transition: color 0.5s ease;
@@ -286,8 +286,8 @@ Full-Width Styles
   border-bottom-right-radius: 2px;
 }
 
-#header_wrap {
-  background: #212121;
+#header_wrap, #footer_wrap {
+  background: #f5664d;
 }
 
 #header_wrap .inner {
@@ -350,7 +350,7 @@ Full-Width Styles
 }
 
 #main_content_wrap {
-  background: #f2f2f2;
+  background-color: #faf4f1;
   border-top: 1px solid #111;
   border-bottom: 1px solid #111;
 }
@@ -359,9 +359,6 @@ Full-Width Styles
   padding-top: 40px;
 }
 
-#footer_wrap {
-  background: #212121;
-}
 
 /*******************************************************************************
 Small Device Styles


### PR DESCRIPTION
Pull styles from emberjs.com to update the following:
  header and footer background color
  page background color
  font types & colors

Here is a screenshot preview:
![overview___ember_app_kit](https://f.cloud.github.com/assets/514063/1178053/0ecc8a1c-219b-11e3-9773-38bbd3d7f2fe.png)

I'm not a designer and the pages could use more work, but I figured I would take a quick pass and try to integrate the emberjs.com grey/orange
