### PR TITLE
fix color for background below footer

### DIFF
--- a/assets/styles/slate.css
+++ b/assets/styles/slate.css
@@ -55,7 +55,7 @@ Theme Styles
 body {
   box-sizing: border-box;
   color: #444444;
-  background: #212121;
+  background: #f5664d;
   font-size: 16px;
   font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
   line-height: 1.5;


### PR DESCRIPTION
Incorrect bg color:
![testing_with_karma___ember_app_kit](https://f.cloud.github.com/assets/514063/1180352/f82210dc-21f1-11e3-842b-675778ef24c0.png)

Correct bg color:
![testing_with_karma___ember_app_kit](https://f.cloud.github.com/assets/514063/1180354/03b06c64-21f2-11e3-92c1-9edc8853335b.png)

You only see this issue on pages that do not stretch full length, such as testing.html that has not had content filled in yet.
