### PR TITLE
Use resolveOther to resolve template modules.

### DIFF
--- a/vendor/resolver.js
+++ b/vendor/resolver.js
@@ -100,15 +100,10 @@ define("resolver",
       return this._super(parsedName);
     }
   }
-
-  function resolveTemplate(parsedName) {
-    return Ember.TEMPLATES[parsedName.name] || Ember.TEMPLATES[Ember.String.underscore(parsedName.name)];
-  }
-
   // Ember.DefaultResolver docs:
   //   https://github.com/emberjs/ember.js/blob/master/packages/ember-application/lib/system/resolver.js
   var Resolver = Ember.DefaultResolver.extend({
-    resolveTemplate: resolveTemplate,
+    resolveTemplate: resolveOther,
     resolveOther: resolveOther,
     parseName: parseName,
     normalize: function(fullName) {


### PR DESCRIPTION
Since the latest version or `grunt-ember-templates` (0.4.15) creates AMD packages instead of using the Ember.TEMPLATES global the old `resolveTemplate` function would always return `undefined` since `Ember.TEMPLATES` is empty.

I found this while debugging https://github.com/stefanpenner/ember-app-kit/issues/191.  This does not fix the issue I had in there, but I _think_ this change is needed regardless.
