### PR TITLE
Ensure that components are registered properly.

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -1,10 +1,20 @@
 import Resolver from 'resolver';
+import registerComponents from 'appkit/utils/register_components';
 
 var App = Ember.Application.extend({
+  LOG_MODULE_RESOLVER: true,
   LOG_ACTIVE_GENERATION: true,
   LOG_VIEW_LOOKUPS: true,
   modulePrefix: 'appkit', // TODO: loaded via config
   Resolver: Resolver
 });
+
+App.initializer({
+  name: 'Register Components',
+  initialize: function(container, application) {
+    registerComponents(container);
+  }
+});
+
 
 export default App;

--- a/app/components/pretty-color.js
+++ b/app/components/pretty-color.js
@@ -1,0 +1,9 @@
+var PrettyColor = Ember.Component.extend({
+    classNames: ['pretty-color'],
+    attributeBindings: ['style'],
+    style: function(){
+      return 'color: ' + this.get('name') + ';';
+    }.property('name')
+});
+
+export default PrettyColor;

--- a/app/router.js
+++ b/app/router.js
@@ -1,6 +1,7 @@
 var Router = Ember.Router.extend(); // ensure we don't share routes between all Router instances
 
 Router.map(function(){
+  this.route('component-test');
   // this.resource('posts', function() {
   //   this.route('new');
   // });

--- a/app/routes/component_test.js
+++ b/app/routes/component_test.js
@@ -1,0 +1,8 @@
+var ComponentTestRoute = Ember.Route.extend({
+  model: function() {
+    return ['purple', 'green', 'orange'];
+  }
+});
+
+export default ComponentTestRoute;
+

--- a/app/templates/component-test.hbs
+++ b/app/templates/component-test.hbs
@@ -1,0 +1,3 @@
+{{#each}}
+  {{pretty-color name=this}}
+{{/each}}

--- a/app/templates/components/pretty-color.hbs
+++ b/app/templates/components/pretty-color.hbs
@@ -1,0 +1,1 @@
+Pretty Color: {{name}}

--- a/app/utils/register_components.js
+++ b/app/utils/register_components.js
@@ -1,0 +1,33 @@
+function registerComponents(container) {
+  var seen = requirejs._eak_seen;
+  var templates = seen, match;
+  if (!templates) { return; }
+
+  for (var prop in templates) {
+    if (match = prop.match(/components\/(.*)$/)) {
+      require(prop, null, null, true);
+      registerComponent(container, match[1]);
+    }
+  }
+}
+
+
+function registerComponent(container, name) {
+  Ember.assert("You provided a template named 'components/" + name + "', but custom components must include a '-'", name.match(/-/));
+
+  var fullName         = 'component:' + name,
+      templateFullName = 'template:components/' + name;
+
+  container.injection(fullName, 'layout', templateFullName);
+
+  var Component = container.lookupFactory(fullName);
+
+  if (!Component) {
+    container.register(fullName, Ember.Component);
+    Component = container.lookupFactory(fullName);
+  }
+
+  Ember.Handlebars.helper(name, Component);
+}
+
+export default registerComponents;

--- a/tests/acceptance/component_test.js
+++ b/tests/acceptance/component_test.js
@@ -1,0 +1,23 @@
+var App;
+
+module("Acceptances - Component", {
+  setup: function(){
+    App = startApp();
+  },
+  teardown: function() {
+    Ember.run(App, 'destroy');
+  }
+});
+
+test("component output is rendered", function(){
+  expect(3);
+
+  visit('/component-test').then(function(){
+    ok(exists("h2:contains('Welcome to Ember.js')"));
+
+    var list = find(".pretty-color");
+    equal(list.length, 3);
+    equal(list.first().text(), "Pretty Color: purple\n");
+  });
+});
+


### PR DESCRIPTION
This PR utilizes our custom Almond property (_eak_seen) to register each 
component automatically.

This resolves #191, but it will need to be revisited when/if we remove our
freedom-patched version of `almond.js`.
