### PR TITLE
Partial updates for scripts, templates and styles

### DIFF
--- a/tasks/options/watch.js
+++ b/tasks/options/watch.js
@@ -1,14 +1,28 @@
 var Helpers = require('../helpers');
 
+var scripts = '{app,tests}/**/*.{js,coffee}';
+var templates = 'app/templates/**/*.{hbs,handlebars,hjs,emblem}';
+var styles = 'app/styles/**/*.{css,sass,scss,less,styl}';
+var other = '{app,tests,public,vendor}/**/*';
+
 module.exports = {
-  main: {
-    files: ['app/**/*', 'public/**/*', 'vendor/**/*', 'tests/**/*'],
-    tasks: ['build:debug']
+  scripts: {
+    files: [scripts],
+    tasks: ['lock', 'buildScripts', 'unlock', 'karma:server:run']
   },
-  test: {
-    files: ['app/**/*', 'public/**/*', 'vendor/**/*', 'tests/**/*'],
+  templates: {
+    files: [templates],
+    tasks: ['lock', 'buildTemplates:debug', 'unlock', 'karma:server:run']
+  },
+  styles: {
+    files: [styles],
+    tasks: ['lock', 'buildStyles', 'unlock', 'karma:server:run']
+  },
+  other: {
+    files: [other, '!'+scripts, '!'+templates, '!'+styles],
     tasks: ['build:debug', 'karma:server:run']
   },
+
   options: {
     debounceDelay: 200,
     livereload: Helpers.isPackageAvailable("connect-livereload")


### PR DESCRIPTION
This is the first change of more to come I'd like to incorporate into our grunt pipeline. It makes quick changes to templates possible and speeds up changes to scripts and styles. It's done by just updating the templates/styles/scripts not everything everytime. If the user changes something else it rebuilds everything as before.

I've still great changes planned, this is just the first step - I'm calling it the bronze edition. I mainly discussed my ideas there: https://github.com/stefanpenner/ember-app-kit/issues/172

Soon:
- Silver edition:
  - autoprefixer
  - more extensive use of the static connect middleware, less file copying
  - grunt-preprocess instead of dum_munger
  - `index.html` in `app/`
- Gold edition:
  - sprite sheets
  - handlebars and emblem can be used at the same time
  - sass, less, stylus, css can be used at the same time
  - info graphics that represent the grunt pipeline exactly, early versions can be found in https://github.com/stefanpenner/ember-app-kit/issues/172

This PR is as far as I can tell ready to merge. It worked fine for me. If problems occour, I'll track them down.

---

This pull request previously changed how grunt tasks and options are arranged. I'm still a big fan of it and will come back to it soon.
