### PR TITLE
Add example of container-renderable helpers

### DIFF
--- a/app/helpers/reverse-word.js
+++ b/app/helpers/reverse-word.js
@@ -1,0 +1,5 @@
+var reverseWord = Ember.Handlebars.makeBoundHelper(function(word) {
+  return word.split('').reverse().join('');
+});
+
+export default reverseWord;

--- a/app/router.js
+++ b/app/router.js
@@ -1,7 +1,8 @@
 var Router = Ember.Router.extend(); // ensure we don't share routes between all Router instances
 
-Router.map(function(){
+Router.map(function() {
   this.route('component-test');
+  this.route('helper-test');
   // this.resource('posts', function() {
   //   this.route('new');
   // });

--- a/app/routes/helper_test.js
+++ b/app/routes/helper_test.js
@@ -1,0 +1,9 @@
+var HelperTestRoute = Ember.Route.extend({
+  model: function() {
+    return {
+      name: "rebmE"
+    };
+  }
+});
+
+export default HelperTestRoute;

--- a/app/templates/helper-test.hbs
+++ b/app/templates/helper-test.hbs
@@ -1,0 +1,1 @@
+<h3>My name is {{reverse-word name}}.</h3>

--- a/bower.json
+++ b/bower.json
@@ -6,5 +6,8 @@
     "qunit": "~1.12.0",
     "ember": "1.2.0-beta.1",
     "ember-data-shim": "1.0.0-beta.3"
+  },
+  "resolutions": {
+    "ember": "1.2.0-beta.1"
   }
 }

--- a/tests/acceptance/helper_test.js
+++ b/tests/acceptance/helper_test.js
@@ -1,0 +1,19 @@
+var App;
+
+module("Acceptances - Helper", {
+  setup: function(){
+    App = startApp();
+  },
+  teardown: function() {
+    Ember.run(App, 'destroy');
+  }
+});
+
+test("helper output is rendered", function(){
+  expect(1);
+
+  visit('/helper-test').then(function(){
+    ok(exists("h3:contains('My name is Ember.')"));
+  });
+});
+


### PR DESCRIPTION
- Dasherized helpers/components are now looked up on the container
- Added helper_test to demonstrate how this works in EAK
- Added resolution to bower.json to prefer Ember Beta
