### PR TITLE
Adding `DS` to jshint "predef"

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -6,6 +6,7 @@
     "setTimeout",
     "Ember",
     "Em",
+    "DS",
     "$"
   ],
   "node" : false,


### PR DESCRIPTION
prevent jshint warning an error when build process.
