### PR TITLE
Changed Ember dependency for Emblem grunt task.

### DIFF
--- a/tasks/options/emblem.js
+++ b/tasks/options/emblem.js
@@ -7,7 +7,7 @@ module.exports = {
       root: 'app/templates/',
       dependencies: {
         jquery: 'vendor/jquery/jquery.js',
-        ember: 'vendor/ember/index.js',
+        ember: 'vendor/ember/ember.js',
         handlebars: 'vendor/handlebars/handlebars.js',
         emblem: 'vendor/emblem.js/emblem.js'
       }


### PR DESCRIPTION
The recent change with Bower and Ember broke Emblem's build task; this resolves the issue.
