### PR TITLE
Remove watching of vendor files

### DIFF
--- a/tasks/options/watch.js
+++ b/tasks/options/watch.js
@@ -2,11 +2,11 @@ var Helpers = require('../helpers');
 
 module.exports = {
   main: {
-    files: ['app/**/*', 'public/**/*', 'vendor/**/*', 'tests/**/*'],
+    files: ['app/**/*', 'public/**/*', 'tests/**/*'],
     tasks: ['build:debug']
   },
   test: {
-    files: ['app/**/*', 'public/**/*', 'vendor/**/*', 'tests/**/*'],
+    files: ['app/**/*', 'public/**/*', 'tests/**/*'],
     tasks: ['build:debug', 'karma:server:run']
   },
   options: {


### PR DESCRIPTION
When appending repositories from GIT the number of files in vendor quickly adds up, which leads to a really fuzzy too many open files error in nodejs, also described in http://stackoverflow.com/questions/8965606/node-and-error-emfile-too-many-open-files

Restarting your `grunt server` after adding vendor scripts seems more reasonable than the EMFILE error, which cost me one hour googling+debugging.
