### PR TITLE
Add `wait` and `keyEvent` test helpers to jshint predef

### DIFF
--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -34,6 +34,8 @@
     "fillIn",
     "click",
     "find",
+    "wait",
+    "keyEvent",
     "isolatedContainer",
     "startApp"
   ],


### PR DESCRIPTION
Mute JSHint warnings caused by unchained `wait` and `keyEvent` helpers when building test suite.
