### PR TITLE
Improve locality of test errors

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -17,7 +17,7 @@ module.exports = function(config) {
       'vendor/ember-data-shim/ember-data.js',
       'assets/templates.js',
       'assets/app.js',
-      'tests/tests.js',
+      '../transpiled/tests/**/*.js',
       'tests/test_helper.js',
       'tests/test_loader.js'
     ],


### PR DESCRIPTION
As mentioned in https://github.com/stefanpenner/ember-app-kit/issues/208 this pull requests runs tests against the individual files in the `tmp/transpiled/tests` folder. The main benefit is when errors occur karma reports the filename and line number of the error in the transpiled file. Due to the nature of transpiled code this is not a 100% accurate representation of where the error lives in the original test file it does make it much easier for the developer to locate the error because transpiled filenames match the original filename and line numbers are usually within ~5 lines of the original source.

One thing this pull request does not do is replace the app.js file withe the individual transpiled files. Doing so may help the developer locate errors in their application code. With my current usage of EAK I haven't found this to be a problem because most of my potential application errors are spotted by jshint or caught by an RSVP promise. However, this may be a change to consider in the future.

Below is an example of the output of a test error. To generate this error I changed `deepEqual(route.model(), ['red', 'yellow', 'blue']);` to `deepEqual(route.model(), ['red', 'yellow', 'black']);` at https://github.com/stefanpenner/ember-app-kit/blob/master/tests/unit/routes/index_test.js#L20 in the stock EAK repo.

Karma output when loading  `tests/tests.js`:

```
Chrome 29.0.1547 (Mac OS X 10.7.5) Unit - IndexRoute #model FAILED
    undefined
        at Object.<anonymous> (/Users/bmac/Dropbox/code/ember-app-kit/tmp/public/tests/tests.js:133:7)
        at Object.Test.run (/Users/bmac/Dropbox/code/ember-app-kit/node_modules/karma-qunit/lib/qunit.js:136:18)
        at /Users/bmac/Dropbox/code/ember-app-kit/node_modules/karma-qunit/lib/qunit.js:279:10
        at process (/Users/bmac/Dropbox/code/ember-app-kit/node_modules/karma-qunit/lib/qunit.js:1277:24)
        at /Users/bmac/Dropbox/code/ember-app-kit/node_modules/karma-qunit/lib/qunit.js:383:5
Chrome 29.0.1547 (Mac OS X 10.7.5): Executed 4 of 4 (1 FAILED) (1.823 secs / 0.815 secs)
```

Karma output when loading  `../transpiled/tests/**/*.js`:

```
Chrome 29.0.1547 (Mac OS X 10.7.5) Unit - IndexRoute #model FAILED
    undefined
        at Object.<anonymous> (/Users/bmac/Dropbox/code/ember-app-kit/tmp/transpiled/tests/unit/routes/index_test.js:23:7)
        at Object.Test.run (/Users/bmac/Dropbox/code/ember-app-kit/node_modules/karma-qunit/lib/qunit.js:136:18)
        at /Users/bmac/Dropbox/code/ember-app-kit/node_modules/karma-qunit/lib/qunit.js:279:10
        at process (/Users/bmac/Dropbox/code/ember-app-kit/node_modules/karma-qunit/lib/qunit.js:1277:24)
        at /Users/bmac/Dropbox/code/ember-app-kit/node_modules/karma-qunit/lib/qunit.js:383:5
Chrome 29.0.1547 (Mac OS X 10.7.5): Executed 4 of 4 (1 FAILED) (1.519 secs / 0.661 secs)
-------------------+-----------+-----------+-----------+-----------+
```
