### PR TITLE
`build:dist` is now just called `dist`

### DIFF
--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -164,9 +164,7 @@ If you'd like to peek into the innards of Ember App Kit's build pipeline, you ca
 
 * `grunt server` - As you saw above, this command builds your application (in *debug* mode) and serves it. This task also will *watch* your application for changes, and will rebuild any time you change a file.
 
-* `grunt build:debug` - Builds your application once in *debug* mode. This will output your app in `tmp/public`.
-
-* `grunt build:dist` - Builds your application once in *dist* mode. This means your assets will be minified and version-stamped. This task also builds to the `dist/` folder, which can be deployed to a static server in production.
+* `grunt dist` - Builds your application once in *dist* mode. This means your assets will be minified and version-stamped. This task also builds to the `dist/` folder, which can be deployed to a static server in production.
 
 * `grunt server:dist` - Same as above, but also launches a preview server for your optimized output.
 


### PR DESCRIPTION
See https://github.com/stefanpenner/ember-app-kit/pull/254
