### PR TITLE
Fix issue with extracted resolver.

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -8,7 +8,7 @@ var App = Ember.Application.extend({
   LOG_TRANSITIONS_INTERNAL: true,
   LOG_VIEW_LOOKUPS: true,
   modulePrefix: 'appkit', // TODO: loaded via config
-  Resolver: Resolver
+  Resolver: Resolver.default
 });
 
 App.initializer({


### PR DESCRIPTION
The resolver now exports a default module (as is the ES6 pattern).

Resolves https://github.com/stefanpenner/ember-app-kit/issues/269.
