### PR TITLE
Fix issue with extracted resolver.

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -8,7 +8,7 @@ var App = Ember.Application.extend({
   LOG_TRANSITIONS_INTERNAL: true,
   LOG_VIEW_LOOKUPS: true,
   modulePrefix: 'appkit', // TODO: loaded via config
-  Resolver: Resolver
+  Resolver: Resolver.default
 });
 
 App.initializer({

--- a/tests/helpers/isolated_container.js
+++ b/tests/helpers/isolated_container.js
@@ -2,7 +2,7 @@ import Resolver from 'resolver';
 
 function isolatedContainer(fullNames) {
   var container = new Ember.Container();
-  var resolver = Resolver.create();
+  var resolver = Resolver.default.create();
 
   resolver.namespace = {
     modulePrefix: 'appkit'


### PR DESCRIPTION
The resolver now exports a default module (as is the ES6 pattern).

Resolves https://github.com/stefanpenner/ember-app-kit/issues/269.
