### PR TITLE
Add TypeScript support

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,6 +5,11 @@ module.exports = function(grunt) {
   //
   // * for Coffeescript, run `npm install --save-dev grunt-contrib-coffee`
   //
+  // * for TypeScript, run `npm install --save-dev grunt-simple-typescript`.
+  //   TypeScript also requires that your app prefix ("appkit" by default)
+  //   be the same as the directory your app has as a home ("app" by default).
+  //   See the tasks/options/simple-typescript.js file for more details.
+  //
   // * for SCSS (without SASS), run `npm install --save-dev grunt-sass`
   // * for SCSS/SASS support (may be slower), run
   //   `npm install --save-dev grunt-contrib-sass`
@@ -174,6 +179,7 @@ module.exports = function(grunt) {
 
   // Scripts
   grunt.registerTask('buildScripts', filterAvailable([
+                     'simple-typescript',
                      'coffee',
                      'copy:javascriptToTmp',
                      'transpile',

--- a/tasks/helpers.js
+++ b/tasks/helpers.js
@@ -7,6 +7,7 @@ var grunt = require('grunt'),
 // e.g. ['a', ['b', 'alternative-to-b']]
 var taskRequirements = {
   'coffee': ['grunt-contrib-coffee'],
+  'simple-typescript': ['grunt-simple-typescript'],
   'compass': ['grunt-contrib-compass'],
   'sass': [['grunt-sass', 'grunt-contrib-sass']],
   'less': ['grunt-contrib-less'],

--- a/tasks/options/simple-typescript.js
+++ b/tasks/options/simple-typescript.js
@@ -1,0 +1,86 @@
+// TypeScript compilation. This must be enabled by installing
+// the the typescript grunt task, as described in the Gruntfile.js
+//
+// TypeScript has a very idiosyncratic (and in several ways immature)
+// module system. This version of TypeScript support, in order to play
+// nicely with the transpiled JavaScript, uses a special NamedAsynchronous
+// module that modifies AMD modules to have names. This is not
+// supported by the TypeScript compiler out of the box.
+//
+// TypeScript files should use the TypeScript module system, inspired
+// by a ES6 module system draft:
+//
+// declare class Ember {
+//   static Route: any;
+// };
+//
+// var IndexRoute = Ember.Route.extend({
+//   model: function() {
+//     return ['red', 'yellow', 'blue'];
+//   }
+// });
+//
+// export = IndexRoute;
+//
+// And an example of a test that uses import:
+//
+// /// <reference path="../../../app/routes/index.ts"/>
+// import Index = require('app/routes/index');
+//
+// declare var module: any;
+// declare var test: any;
+// declare var isolatedContainer: any;
+// declare var ok: any;
+// declare var Ember: any;
+//
+// var route: any;
+//
+// module("Unit - IndexRoute", {
+//   setup: function(){
+//     var container = isolatedContainer([
+//       'route:index'
+//     ]);
+//     route = container.lookup('route:index');
+//   }
+// });
+//
+// test("it exists", function(){
+//   ok(route);
+//   ok(route instanceof Index);
+// });
+//
+// The reference is required to allow the require statement
+// to find a description of the module. This is what requires
+// your app to have the same namespaces as the directory is
+// calls home.
+//
+var grunt = require('grunt');
+
+module.exports = {
+  "test": {
+    moduleGenTarget: 'NamedAsynchronous',
+    moduleName: function(path) {
+      return grunt.config.process('<%= package.namespace %>/tests/') + path;
+    },
+    files: [{
+      expand: true,
+      cwd: 'tests/',
+      src: "**/*.ts",
+      dest: "tmp/transpiled/tests/",
+      ext: '.js'
+    }]
+  },
+  "app": {
+    moduleGenTarget: 'NamedAsynchronous',
+    moduleName: function(path) {
+      return grunt.config.process('<%= package.namespace %>/') + path.substring(4,path.length);
+    },
+    files: [{
+      expand: true,
+      cwd: 'app/',
+      src: "**/*.ts",
+      dest: "tmp/transpiled/app/",
+      ext: '.js'
+    }]
+  }
+};


### PR DESCRIPTION
This commit adds support for [TypeScript](http://www.typescriptlang.org/) along side other JavaScript pre-processors. Very open to review. We can upstream it, or decide nobody wants it, or decide there are too many compromises. Please discuss.

Two examples:
- App with mixed usage: https://github.com/mixonic/ember-app-kit/tree/typescript-example
- App based on an older version of this code, but 100% TypeScript: https://github.com/mixonic/ember-app-kit/tree/typescript

TypeScript's module system is less robust than you might hope for. There is no support for named modules and the core team has expressed a distaste for the idea until after 1.0. This solution relies on a Grunt package @bantic and I wrote that supports named modules. It is tested and used.

Another quirk is that TypeScript, due to how it resolves modules for typing, requires that the AMD module name be the same (ish) as the name on disk. I could address this with further customization of the compiler, but I would like to avoid that. Instead I suggest that users of this grunt path be required to name their apps `app`, or whatever the name of their app directory is.

And I will likely have another PR coming that makes that change, also open for discussion. For now, go wild with some typed JavaScript! I suggest looking at the `definitions` folder of the 100% TypeScript app to get some definition files.
