### PR TITLE
Explicitly force the router to use hash location when testing. Fix #202

### DIFF
--- a/tests/helpers/start_app.js
+++ b/tests/helpers/start_app.js
@@ -18,7 +18,7 @@ function startApp(attrs) {
   });
 
   Router.reopen({
-    location: 'none'
+    location: 'hash'
   });
 
   App.reset(); // this shouldn't be needed, i want to be able to "start an app at a specific URL"


### PR DESCRIPTION
This also fixes #202 where using history state breaks testing. As an alternate to using none, this patch preserves default behavior.
