### PR TITLE
Advance readiness (no need for reset).

### DIFF
--- a/tests/helpers/start_app.js
+++ b/tests/helpers/start_app.js
@@ -21,7 +21,7 @@ function startApp(attrs) {
     location: 'hash'
   });
 
-  App.reset(); // this shouldn't be needed, i want to be able to "start an app at a specific URL"
+  Ember.run(App, 'advanceReadiness');
 
   return App;
 }


### PR DESCRIPTION
I took some time looking into how we could make the `visit` test helper setup routing (instead of relying on `App.reset()`), and discovered that the reason we have to call `App.reset` in our `start_app` helper ([here](https://github.com/stefanpenner/ember-app-kit/blob/8d3f1c6f2fedd7d90fe8f89ed873730b3e18fb3a/tests/helpers/start_app.js#L24)) is because `setupTestHelpers` defers readiness, and without an explicit `advanceReadiness` call our application will never be able to route.  The existing call to `App.reset()` just bypassed that issue since it forcefully sets `App._readinessDeferrals` to 1 and then calls `advanceReadiness`.

This does not address the general Ember issue, but since we are creating a one-off `App` instance in this project it should be all we need for now.
