### PR TITLE
Speed up watching

### DIFF
--- a/tasks/options/watch.js
+++ b/tasks/options/watch.js
@@ -29,7 +29,10 @@ module.exports = {
   },
 
   options: {
-    debounceDelay: 200,
+    // No need to debounce
+    debounceDelay: 0,
+    // When we don't have inotify, we still want to be snappy
+    interval: 20,
     livereload: Helpers.isPackageAvailable("connect-livereload")
   }
 };


### PR DESCRIPTION
On my Linux, it's not using inotify for some reason -- perhaps some
issue with the gaze package (https://github.com/shama/gaze). We should
be using inotify eventually, but when we're not, we still want to be
fast. 20ms polling interval on a 100ms build step seems alright.

---

I don't believe we need debouncing at all, do we?
