### PR TITLE
Fix the path to the assets directory so the coverage metrics are reporte...

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -31,7 +31,7 @@ module.exports = function(config) {
     ],
 
     preprocessors: {
-      'assets/*.js': 'coverage'
+      'tmp/result/assets/*.js': 'coverage'
     },
 
     // list of files to exclude


### PR DESCRIPTION
...d correctly

I just updated my EAK project to use the latest cover and discovered my code coverage percent jumped to 100%. Upon further investigation it seems the coverage preprocessor was not being run on the correctly directory so karma though my app had 0 lines of code. This pr updates the path in `karam.conf.js` so the coverage is once again reported accurately. 
