### PR TITLE
Update Bower configuration.

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -21,7 +21,7 @@
     <script src="/vendor/ember/ember.prod.js"></script>
     <!-- @endif -->
 
-    <script src="/vendor/ember-data-shim/ember-data.js"></script>
+    <script src="/vendor/ember-data/ember-data.js"></script>
     <script src="/vendor/loader.js"></script>
     <script src="/vendor/ember-resolver/dist/ember-resolver.js"></script>
 

--- a/bower.json
+++ b/bower.json
@@ -1,14 +1,15 @@
 {
   "name": "ember-app-kit",
   "dependencies": {
-    "handlebars": "1.0.0",
+    "handlebars": "~1.1.2",
     "jquery": "~1.9.1",
     "qunit": "~1.12.0",
-    "ember": "~>1.2.0-beta.1",
-    "ember-data-shim": "1.0.0-beta.3",
+    "ember": "~1.2.0-beta.1",
+    "ember-data": "~1.0.0-beta.3",
     "ember-resolver": "git://github.com/stefanpenner/ember-jj-abrams-resolver.git#master"
   },
   "resolutions": {
-    "ember": "~>1.2.0-beta.1"
+    "ember": "~1.2.0-beta.1",
+    "handlebars": "~1.1.2"
   }
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -11,7 +11,7 @@ module.exports = function(config) {
       'vendor/jquery/jquery.js',
       'vendor/handlebars/handlebars.js',
       'vendor/ember/ember.js',
-      'vendor/ember-data-shim/ember-data.js',
+      'vendor/ember-data/ember-data.js',
       'tmp/result/assets/templates.js',
       'tmp/result/assets/app.js',
       'tmp/transpiled/tests/**/*.js',


### PR DESCRIPTION
- Use Handlebars `~>1.1.2` (will allow everything `< 1.2`).
- Replace `ember-data-shim` with `ember-data`. @fivetanley had the Bower
  registry fixed so that `ember-data-shim` and `ember-data` both point
  to https://github.com/components/ember-data. (FYI - Sometime in the future we
  will be removing `ember-data-shim`.)
