### PR TITLE
Use vendored template compiler.

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "grunt-concurrent": "~0.3.1",
     "grunt-usemin": "~0.1.12",
     "grunt-rev": "~0.1.0",
-    "grunt-ember-templates": "~0.4.15",
+    "grunt-ember-templates": "~0.4.17",
     "grunt-karma": "~0.5",
     "karma": "~0.9.4",
     "karma-qunit": "~0.0.3",

--- a/tasks/options/emberTemplates.js
+++ b/tasks/options/emberTemplates.js
@@ -6,7 +6,9 @@ module.exports = {
     templateFileExtensions: /\.(hbs|hjs|handlebars)/,
     templateRegistration: function(name, template) {
       return grunt.config.process("define('<%= package.namespace %>/") + name + "', ['exports'], function(__exports__){ __exports__['default'] = " + template + "; });";
-    }
+    },
+    templateCompilerPath: 'vendor/ember/ember-template-compiler.js',
+    handlebarsPath: 'vendor/handlebars/handlebars.js'
   },
   debug: {
     options: {


### PR DESCRIPTION
Recent changes to Ember 1.2.0-beta.3 broke compatiblity with templates 
compiled with prior versions of the `ember-template-compiler`.

This change allows us to use the version bundled in Bower with ember itself.

Additional Notes:
- `grunt-ember-templates` added support for using custom templateCompilerPath/handlebarsPath in v0.4.17 (see [here](https://github.com/dgeb/grunt-ember-templates/pull/53)).
- The Ember package in bower is now publishing the template compiler (see [here](https://github.com/components/ember/commit/a1fc1f0f77d6cbeb854c9ba5ad328977e3e08d90)).
- A PR has been submitted to Ember (see
  [here](https://github.com/emberjs/ember.js/pull/3776)) to publish the
  template compiler along with release/beta/canary builds.
