### PR TITLE
Fixes `Uncaught TypeError: Cannot read property default of undefined`

### DIFF
--- a/vendor/loader.js
+++ b/vendor/loader.js
@@ -32,7 +32,7 @@ var define, requireModule, require, requirejs;
     }
 
     var value = callback.apply(this, reified);
-    return seen[name] = exports || value;
+    return seen[name] = value || exports;
 
     function resolve(child) {
       if (child.charAt(0) !== '.') { return child; }


### PR DESCRIPTION
![app 2013-11-25 09-30-21](https://f.cloud.github.com/assets/1131196/1613720/1e08cd66-55de-11e3-8ce1-18f9e2ff1888.jpg)

Resolver isn't loaded properly and it throws the error after getting latest from master.
