### PR TITLE
Added a note to reverse-word.js about the need for Handlebars helpers to contain a dash.

### DIFF
--- a/app/helpers/reverse-word.js
+++ b/app/helpers/reverse-word.js
@@ -1,6 +1,6 @@
 // Please note that Handlebars helpers will only be found automatically by the
 // resolver if their name contains a dash (reverse-word, translate-text, etc.)
-// See, for more details: https://github.com/stefanpenner/ember-app-kit/wiki/Getting-Started#resolving-handlebars-helpers
+// For more details: http://stefanpenner.github.io/ember-app-kit/guides/using-modules.html
 
 export default Ember.Handlebars.makeBoundHelper(function(word) {
   return word.split('').reverse().join('');


### PR DESCRIPTION
Handlebars helpers' name need to have a dash, or they won't be found by the (lazy) resolver, unless they're declared explicitly. I added a note to the reverse-word.js example to help make this clear.
