### PR TITLE
Switched to a custom version of load-grunt-config to allow custom grunt configs.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -53,7 +53,8 @@ module.exports = function(grunt) {
   // Loads task options from `tasks/options/`
   // and loads tasks defined in `package.json`
   var config = require('load-grunt-config')(grunt, {
-    configPath: path.join(__dirname, 'tasks/options'),
+    defaultPath: path.join(__dirname, 'tasks/options'),
+    configPath: path.join(__dirname, 'tasks/custom'),
     init: false
   });
   grunt.loadTasks('tasks'); // Loads tasks in `tasks/` folder

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "bower": "~1.2.7",
     "grunt": "~0.4.1",
     "grunt-cli": "~0.1.9",
-    "load-grunt-config": "~0.7.0",
+    "load-grunt-config": "git://github.com/Pradeek/load-grunt-config.git",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-concat": "~0.3.0",


### PR DESCRIPTION
This is for separating the grunt tasks in EAK to allow easier upgrades. [#256](https://github.com/stefanpenner/ember-app-kit/issues/256)

Specified my fork of load-grunt-config in package.json as of now. We can switch back to the official repo when the pull request for this is merged in.

To maintain backwards compatibility, I've specified custom options to be set in tasks/custom. We can discuss on where we want to specify that. Ideally I'd like to have it as tasks/vendor and tasks/option for appkit and user custom respectively. 

To try this out, create a config in tasks/custom that overrides the same task in tasks/options. It currently merges the two configs, may want to have an option to cleanly override in the future. 
