### PR TITLE
Proxy method can be specified via arguments

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -85,12 +85,18 @@ module.exports = function(grunt) {
 
   // Servers
   // -------------------
-  grunt.registerTask('server', "Run your server in development mode, auto-rebuilding when files change.", [
-                     'clean:debug',
-                     'build:debug',
-                     'expressServer:debug',
-                     'watch'
-                     ]);
+  grunt.registerTask('server', "Run your server in development mode, auto-rebuilding when files change.", function(proxyMethod) {
+    var expressServerTask = 'expressServer:debug';
+    if (proxyMethod) {
+      expressServerTask += ':' + proxyMethod;
+    }
+
+    grunt.task.run(['clean:debug',
+                    'build:debug',
+                    expressServerTask,
+                    'watch'
+                    ]);
+  });
 
   grunt.registerTask('server:dist', "Build and preview a minified & production-ready version of your app.", [
                      'dist',
@@ -109,14 +115,20 @@ module.exports = function(grunt) {
   grunt.registerTask('test:browsers', "Run your app's tests in multiple browsers (see tasks/options/karma.js for configuration).", [
                      'clean:debug', 'build:debug', 'karma:browsers' ]);
 
-  grunt.registerTask('test:server', "Start a Karma test server and the standard development server.", [
-                     'clean:debug',
-                     'build:debug',
-                     'karma:server',
-                     'expressServer:debug',
-                     'addKarmaToWatchTask',
-                     'watch'
-                     ]);
+  grunt.registerTask('test:server', "Start a Karma test server and the standard development server.", function(proxyMethod) {
+    var expressServerTask = 'expressServer:debug';
+    if (proxyMethod) {
+      expressServerTask += ':' + proxyMethod;
+    }
+
+    grunt.task.run(['clean:debug',
+                    'build:debug',
+                    'karma:server',
+                    expressServerTask,
+                    'addKarmaToWatchTask',
+                    'watch'
+                    ]);
+  });
 
   // Worker tasks
   // =================================

--- a/tasks/express-server.js
+++ b/tasks/express-server.js
@@ -11,31 +11,30 @@ module.exports = function(grunt) {
 
   Note: The expressServer:debug task looks for files in multiple directories.
   */
-  grunt.registerTask('expressServer', function(target) {
+  grunt.registerTask('expressServer', function(target, proxyMethodToUse) {
     // Load namespace module before creating the server
-    require('express-namespace'); 
+    require('express-namespace');
 
     var app = express(),
-        done = this.async();
+        done = this.async(),
+        proxyMethod = proxyMethodToUse || grunt.config('express-server.options.APIMethod');
 
     app.use(lock);
     app.use(express.compress());
 
-    if (grunt.config('express-server.options.APIMethod') === 'stub') {
+    if (proxyMethod === 'stub') {
       grunt.log.writeln('Using API Stub');
-      
+
       // Load API stub routes
       app.use(express.bodyParser());
-      require('../api-stub/routes')(app); 
-    }
-    else {
+      require('../api-stub/routes')(app);
+    } else if (proxyMethod === 'proxy') {
       var proxyURL = grunt.config('express-server.options.proxyURL');
       grunt.log.writeln('Proxying API requests to: ' + proxyURL);
-      
+
       // Use API proxy
       app.all('/api/*', passThrough(proxyURL));
     }
-    
 
     if (target === 'debug') {
       // For `expressServer:debug`


### PR DESCRIPTION
The previously introduced proxy feature can be configured by setting the
`APIMethod` and `proxyURL` properties in the `express-server` options.

This change makes it possible to quickly change the used proxy method by
specifying an argument to the `server` and `test:server` task: to use
the `stub` proxy method, run `grunt server:stub` or `grunt
test:server:stub` and to proxy the requests to a proxy server, invoke
`grunt server:proxy` or `grunt test:server:proxy`.

If no proxy method is specified (aka `grunt:server`), then the proxy
configuration from the `express-server` options is used.

---

This feature is inspired by @ralfschimmel's [comment](https://github.com/stefanpenner/ember-app-kit/pull/304#issuecomment-29445844).
