### PR TITLE
Add ic-ajax to bower.json.

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -24,6 +24,7 @@
     <script src="/vendor/ember-data/ember-data.js"></script>
     <script src="/vendor/loader.js"></script>
     <script src="/vendor/ember-resolver/dist/ember-resolver.js"></script>
+    <script src="/vendor/ic-ajax/main.js"></script>
 
   <!-- endbuild -->
 

--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,8 @@
     "qunit": "~1.12.0",
     "ember": "~1.2.0",
     "ember-data": "~1.0.0-beta.3",
-    "ember-resolver": "git://github.com/stefanpenner/ember-jj-abrams-resolver.git#master"
+    "ember-resolver": "git://github.com/stefanpenner/ember-jj-abrams-resolver.git#master",
+    "ic-ajax": "~0.1"
   },
   "resolutions": {
     "ember": "~1.2.0",

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -12,6 +12,7 @@ module.exports = function(config) {
       'vendor/handlebars/handlebars.js',
       'vendor/ember/ember.js',
       'vendor/ember-data/ember-data.js',
+      'vendor/ic-ajax/main.js',
       'tmp/result/assets/templates.js',
       'tmp/result/assets/app.js',
       'tmp/transpiled/tests/**/*.js',


### PR DESCRIPTION
Unfortunately, our loader doesn't really allow usage of anonymous AMD modules so this still requires the use of globals (`ic-ajax` creates a global named `ic.ajax`).  I do not think this is a blocking issue, just something to note.
