### PR TITLE
Add ES6 wrapper for ic-ajax.

### DIFF
--- a/app/utils/ajax.js
+++ b/app/utils/ajax.js
@@ -1,0 +1,3 @@
+export default function ajax(){
+  return ic.ajax.apply(null, arguments);
+}


### PR DESCRIPTION
I've been using this in my application to allow ES6 style importing, and
it also has the positive benefit of buffering my application's internals
allowing internal `ic-ajax` changes to be managed from a single place.

To import:

``` javascript
import ajax from 'appkit/utils/ajax';
```
