### PR TITLE
whitelist ic for jshint

### DIFF
--- a/app/utils/ajax.js
+++ b/app/utils/ajax.js
@@ -1,3 +1,4 @@
+/* global ic */
 export default function ajax(){
   return ic.ajax.apply(null, arguments);
 }


### PR DESCRIPTION
This is to get rid of the following issue:

Running "jshint:app" (jshint) task
Linting app/utils/ajax.js ...ERROR
[L2:C10] W117: 'ic' is not defined.
  return ic.ajax.apply(null, arguments);
