### PR TITLE
Allow for modules without exports

### DIFF
--- a/vendor/loader.js
+++ b/vendor/loader.js
@@ -10,7 +10,7 @@ var define, requireModule, require, requirejs;
   requirejs = require = requireModule = function(name) {
   requirejs._eak_seen = registry;
 
-    if (seen[name]) { return seen[name]; }
+    if (seen.hasOwnProperty(name)) { return seen[name]; }
     seen[name] = {};
 
     if (!registry[name]) {


### PR DESCRIPTION
They are undefined, so the seen[name] test would previously fail.

---

This is where the circular issues were coming from. :-) I still haven't quite gotten it to work, but we're making progress.

Hm, we should really move this loader into a separate repo at some point.
