### PR TITLE
Latest grunt-ember-templates uses NPM package deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "grunt-concurrent": "~0.3.1",
     "grunt-usemin": "~0.1.12",
     "grunt-rev": "~0.1.0",
-    "grunt-ember-templates": "~0.4.17",
+    "grunt-ember-templates": "~0.4.18",
     "grunt-karma": "~0.5",
     "karma": "~0.9.4",
     "karma-qunit": "~0.0.3",

--- a/tasks/options/emberTemplates.js
+++ b/tasks/options/emberTemplates.js
@@ -6,9 +6,7 @@ module.exports = {
     templateFileExtensions: /\.(hbs|hjs|handlebars)/,
     templateRegistration: function(name, template) {
       return grunt.config.process("define('<%= package.namespace %>/") + name + "', ['exports'], function(__exports__){ __exports__['default'] = " + template + "; });";
-    },
-    templateCompilerPath: 'vendor/ember/ember-template-compiler.js',
-    handlebarsPath: 'vendor/handlebars/handlebars.js'
+    }
   },
   debug: {
     options: {


### PR DESCRIPTION
This allows us to specify the specific versions of
`ember-template-compiler` and `handlebars` that our applications need directly
in our `package.json`.

More details
[here](https://github.com/dgeb/grunt-ember-templates/pull/56).
