### PR TITLE
Add default config setup.

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -13,6 +13,23 @@
 
   <!-- for more details visit: https://github.com/yeoman/grunt-usemin -->
 
+  <!-- build:js(tmp/result) assets/config.min.js -->
+
+    <script src="/config/environment.js"></script>
+    <!-- @if tests=false -->
+
+      <!-- @if dist=false -->
+      <script src="/config/environments/development.js"></script>
+      <!-- @endif --><!-- @if dist=true -->
+      <script src="/config/environments/production.js"></script>
+      <!-- @endif -->
+
+    <!-- @endif --><!-- @if tests=true -->
+      <script src="/config/environments/test.js"></script>
+    <!-- @endif -->
+
+  <!-- endbuild -->
+
   <!-- build:js(tmp/result) assets/vendor.min.js -->
 
     <script src="/vendor/jquery/jquery.js"></script>

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,0 +1,10 @@
+// Put general configuration here. This file is included
+// in both production and development BEFORE Ember is
+// loaded.
+//
+// For example to enable a feature on a canary build you
+// might do:
+//
+// window.ENV = {FEATURES: {'with-controller': true}};
+
+window.ENV = {};

--- a/config/environments/development.js
+++ b/config/environments/development.js
@@ -1,0 +1,4 @@
+// Put your development configuration here.
+// This might be useful when using a separate API 
+// endpoint in development than in production.
+window.ENV = {};

--- a/config/environments/production.js
+++ b/config/environments/production.js
@@ -1,0 +1,4 @@
+// Put your production configuration here.
+//
+// This is useful when using a separate API
+// endpoint in development than in production.

--- a/config/environments/test.js
+++ b/config/environments/test.js
@@ -1,0 +1,5 @@
+// Put your test configuration here.
+//
+// This is useful when using a separate API
+// endpoint in test than in production.
+

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -6,6 +6,8 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
+      'config/environment.js',
+      'config/environments/test.js',
       'vendor/loader.js',
       'vendor/ember-resolver/dist/ember-resolver.js',
       'vendor/jquery/jquery.js',

--- a/tasks/express-server.js
+++ b/tasks/express-server.js
@@ -45,6 +45,7 @@ module.exports = function(grunt) {
       }
 
       // These three lines simulate what the `copy:assemble` task does
+      app.use(static({ urlRoot: '/config', directory: 'config' }));
       app.use(static({ urlRoot: '/vendor', directory: 'vendor' }));
       app.use(static({ directory: 'public' }));
       app.use(static({ urlRoot: '/tests', directory: 'tests' })); // For test_helper.js and test_loader.js

--- a/tasks/options/concat_sourcemap.js
+++ b/tasks/options/concat_sourcemap.js
@@ -7,6 +7,14 @@ module.exports = {
     },
   },
 
+  config: {
+    src: ['tmp/result/config/**/*.js'],
+    dest: 'tmp/result/assets/config.js',
+    options: {
+      sourcesContent: true
+    },
+  },
+
   test: {
     src: 'tmp/transpiled/tests/**/*.js',
     dest: 'tmp/result/tests/tests.js',

--- a/tasks/options/copy.js
+++ b/tasks/options/copy.js
@@ -42,7 +42,11 @@ module.exports = {
     }, {
       src: ['vendor/**/*.js', 'vendor/**/*.css'],
       dest: 'tmp/result/'
+    }, {
+      src: ['config/**/*.js'],
+      dest: 'tmp/result/'
     }
+
     ]
   },
 

--- a/tasks/options/rev.js
+++ b/tasks/options/rev.js
@@ -2,6 +2,7 @@ module.exports = {
   dist: {
     files: {
       src: [
+        'dist/assets/config.min.js',
         'dist/assets/app.min.js',
         'dist/assets/vendor.min.js',
         'dist/assets/app.min.css'


### PR DESCRIPTION
Allows specifying configuration in the following files:
- `config/environment.js` - This is loaded in all enviroments.
- `config/environments/production.js` - This is loaded when
  building with `grunt dist`.
- `config/environments/development.js` - This is loaded when
  building a normal development server (via `grunt server` generally).
- `config/environments/test.js` - This is loaded when running tests via
  either browsing to `/tests` URL or running via karma.
