### PR TITLE
Don't destroy global config object

### DIFF
--- a/config/environments/development.js
+++ b/config/environments/development.js
@@ -1,4 +1,6 @@
 // Put your development configuration here.
-// This might be useful when using a separate API 
+//
+// This is useful when using a separate API 
 // endpoint in development than in production.
-window.ENV = {};
+//
+// window.ENV.public_key = '123456'

--- a/config/environments/production.js
+++ b/config/environments/production.js
@@ -2,3 +2,5 @@
 //
 // This is useful when using a separate API
 // endpoint in development than in production.
+//
+// window.ENV.public_key = '123456'

--- a/config/environments/test.js
+++ b/config/environments/test.js
@@ -2,4 +2,5 @@
 //
 // This is useful when using a separate API
 // endpoint in test than in production.
-
+//
+// window.ENV.public_key = '123456'


### PR DESCRIPTION
This will encourage people not to destory their window.ENV object by
reassigning it a completely new value.

The environemnt specific files should load after `environemnt.js` has
loaded. This way the values assigned to `window.ENV` in those
environment specific files can overwrite any defaults set in
`environment.js`

I have also cleaned up the comments somewhat and included a simple
example of setting a config value.
