### PR TITLE
Suppress Express deprecation warning caused by `bodyParser` middleware

### DIFF
--- a/tasks/express-server.js
+++ b/tasks/express-server.js
@@ -26,7 +26,8 @@ module.exports = function(grunt) {
       grunt.log.writeln('Using API Stub');
 
       // Load API stub routes
-      app.use(express.bodyParser());
+      app.use(express.json());
+      app.use(express.urlencoded());
       require('../api-stub/routes')(app);
     } else if (proxyMethod === 'proxy') {
       var proxyURL = grunt.config('express-server.options.proxyURL');


### PR DESCRIPTION
This removes the following deprecation warning when running the Express server.

```
connect.multipart() will be removed in connect 3.0
visit https://github.com/senchalabs/connect/wiki/Connect-3.0 for alternatives
connect.limit() will be removed in connect 3.0
```
