### PR TITLE
Updated grunt file to reference using appkit compatible loom

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -38,7 +38,7 @@ module.exports = function(grunt) {
   //   `npm install --save-dev grunt-contrib-imagemin`
   //
   // * for using the loom generator to generate routes, controllers, etc.
-  //   efficiently. `npm install --save-dev loom loom-generators-ember`
+  //   efficiently. `npm install --save-dev loom loom-generators-ember-appkit`
   //
 
   var Helpers = require('./tasks/helpers'),


### PR DESCRIPTION
The original npm 'loom-generators-ember' has been changed to common js, so I forked it and published the appkit compatible version of the loom generators.
