### PR TITLE
Only copy production environment config when using grunt dist

### DIFF
--- a/tasks/options/copy.js
+++ b/tasks/options/copy.js
@@ -43,7 +43,7 @@ module.exports = {
       src: ['vendor/**/*.js', 'vendor/**/*.css'],
       dest: 'tmp/result/'
     }, {
-      src: ['config/**/*.js'],
+      src: ['config/environment.js', 'config/environments/production.js'],
       dest: 'tmp/result/'
     }
 


### PR DESCRIPTION
This fixes the configuration when using grunt dist.

Because it's the dist task it assumes that the production configuration is required. Not sure if this is correct though?
