### PR TITLE
Validate port of development server

### DIFF
--- a/tasks/express-server.js
+++ b/tasks/express-server.js
@@ -61,7 +61,10 @@ module.exports = function(grunt) {
       app.use(static({ file: 'dist/index.html' })); // Gotta catch 'em all
     }
 
-    var port = process.env.PORT || 8000;
+    var port = parseInt(process.env.PORT || 8000, 10);
+    if (isNaN(port) || port < 1 || port > 65535) {
+      grunt.fail.fatal('The PORT environment variable of ' + process.env.PORT + ' is not valid.');
+    }
     app.listen(port);
     grunt.log.ok('Started development server on port %d.', port);
     if (!this.flags.keepalive) { done(); }


### PR DESCRIPTION
This commit makes it so that even if PORT is defined to some wacky value it the development server will still work out of the box. It will also log an error letting the user know that there port is configured incorrectly.
