### PR TITLE
Use absolute paths for dist assets

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -7,13 +7,13 @@
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <!-- build:css(tmp/result) assets/app.min.css -->
+  <!-- build:css(tmp/result) /assets/app.min.css -->
   <link rel="stylesheet" href="/assets/app.css">
   <!-- endbuild -->
 
   <!-- for more details visit: https://github.com/yeoman/grunt-usemin -->
 
-  <!-- build:js(tmp/result) assets/config.min.js -->
+  <!-- build:js(tmp/result) /assets/config.min.js -->
 
     <script src="/config/environment.js"></script>
     <!-- @if tests=false -->
@@ -30,7 +30,7 @@
 
   <!-- endbuild -->
 
-  <!-- build:js(tmp/result) assets/vendor.min.js -->
+  <!-- build:js(tmp/result) /assets/vendor.min.js -->
 
     <script src="/vendor/jquery/jquery.js"></script>
 
@@ -49,7 +49,7 @@
 
   <!-- endbuild -->
 
-  <!-- build:js(tmp/result) assets/app.min.js -->
+  <!-- build:js(tmp/result) /assets/app.min.js -->
 
     <script src="/assets/app.js"></script>
     <script src="/assets/templates.js"></script>


### PR DESCRIPTION
Previously the paths of combined assets were relative which caused problems when entering the app via non-root url. E.g. when initially going to http://example.com/foo/bar the assets were pointing to `/foo/assets/...` instead of `/assets/...`
