### PR TITLE
Added autoprefixer, connect-livereload now enabled by default

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,9 +37,12 @@ module.exports = function(grunt) {
   // * for minimizing images in the dist task
   //   `npm install --save-dev grunt-contrib-imagemin`
   //
-  // * for using images based css sprites
+  // * for using images based CSS sprites (http://youtu.be/xD8DW6IQ6r0)
   //   `npm install --save-dev grunt-fancy-sprites`
   //   `bower install --save fancy-sprites-scss`
+  //
+  // * for automatically adding CSS vendor prefixes (autoprefixer)
+  //   `npm install --save-dev grunt-autoprefixer`
   //
 
   var Helpers = require('./tasks/helpers'),
@@ -203,8 +206,8 @@ module.exports = function(grunt) {
                      'sass:compile',
                      'less:compile',
                      'stylus:compile',
-                     'copy:cssToResult'
-                     // ToDo: Add 'autoprefixer'
+                     'copy:cssToResult',
+                     'autoprefixer:app'
                      ]));
 
   // Index HTML

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "request": "~2.27.0",
     "loom-generators-ember-appkit": "~1.0.2",
     "originate": "~0.1.5",
-    "loom": "~3.1.2"
+    "loom": "~3.1.2",
+    "connect-livereload": "~0.3.1"
   }
 }

--- a/tasks/helpers.js
+++ b/tasks/helpers.js
@@ -6,17 +6,18 @@ var grunt = require('grunt'),
 // Notated in conjunctive normal form (CNF)
 // e.g. ['a', ['b', 'alternative-to-b']]
 var taskRequirements = {
-  'coffee': ['grunt-contrib-coffee'],
-  'compass': ['grunt-contrib-compass'],
-  'sass': [['grunt-sass', 'grunt-contrib-sass']],
-  'less': ['grunt-contrib-less'],
-  'stylus': ['grunt-contrib-stylus'],
-  'emberTemplates': ['grunt-ember-templates'],
-  'emblem': ['grunt-emblem'],
-  'emberscript': ['grunt-ember-script'],
-  'imagemin': ['grunt-contrib-imagemin'],
-  'htmlmin': ['grunt-contrib-htmlmin'],
-  'fancySprites': ['grunt-fancy-sprites']
+  coffee: ['grunt-contrib-coffee'],
+  compass: ['grunt-contrib-compass'],
+  sass: [['grunt-sass', 'grunt-contrib-sass']],
+  less: ['grunt-contrib-less'],
+  stylus: ['grunt-contrib-stylus'],
+  emberTemplates: ['grunt-ember-templates'],
+  emblem: ['grunt-emblem'],
+  emberscript: ['grunt-ember-script'],
+  imagemin: ['grunt-contrib-imagemin'],
+  htmlmin: ['grunt-contrib-htmlmin'],
+  fancySprites: ['grunt-fancy-sprites'],
+  autoprefixer: ['grunt-autoprefixer']
 };
 
 // Task fallbacks

--- a/tasks/options/autoprefixer.js
+++ b/tasks/options/autoprefixer.js
@@ -1,0 +1,5 @@
+module.exports = {
+  app: {
+    src: 'tmp/result/assets/**/*.css'
+  }
+};


### PR DESCRIPTION
Autoprefixer is optional.

Livereloading is now enabled by default because using it is best practice. It can still be easily disabled.
