### PR TITLE
Configures Testem to use the test build of index.html

### DIFF
--- a/tasks/options/testem.js
+++ b/tasks/options/testem.js
@@ -7,7 +7,7 @@ module.exports = {
       port: (parseInt(process.env.PORT || 7358, 10) + 1),
       src_files: [
         'tmp/result/{app,tests}/**/*.{js,coffee,css}',
-        'tmp/result/index.html'
+        'tmp/result/test/index.html'
       ],
       serve_files: [
         'vendor/loader.js',
@@ -34,7 +34,7 @@ module.exports = {
       port: (parseInt(process.env.PORT || 7358, 10) + 1),
       src_files: [
         'tmp/result/{app,tests}/**/*.{js,coffee,css}',
-        'tmp/result/index.html'
+        'tmp/result/test/index.html'
       ],
       serve_files: [
         'vendor/loader.js',


### PR DESCRIPTION
The old Karma configuration ran tests against the test build of
index.html (/tmp/result/test/index.html). This updates the configuration
to keep with that setting.
