### PR TITLE
Simplifies testem configuration to reduce duplication

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -94,6 +94,7 @@
   <script src="/tests/tests.js"></script>
   <script src="/tests/test_helper.js"></script>
   <script src="/tests/test_loader.js"></script>
+  <script src="/testem.js"></script>
   <!-- @endif -->
 
   <!-- @if tests=false -->

--- a/tasks/options/testem.js
+++ b/tasks/options/testem.js
@@ -5,24 +5,13 @@ module.exports = {
       parallel: 2,
       framework: 'qunit',
       port: (parseInt(process.env.PORT || 7358, 10) + 1),
-      src_files: [
-        'tmp/result/{app,tests}/**/*.{js,coffee,css}',
-        'tmp/result/test/index.html'
-      ],
-      serve_files: [
-        'vendor/loader.js',
-        'vendor/ember-resolver/dist/ember-resolver.js',
-        'vendor/jquery/jquery.js',
-        'vendor/handlebars/handlebars.js',
-        'vendor/ember/ember.js',
-        'vendor/ember-data/ember-data.js',
-        'vendor/ic-ajax/main.js',
-        'tmp/result/assets/templates.js',
-        'tmp/result/assets/app.js',
-        'tmp/transpiled/tests/**/*.js',
-        'tests/test_helper.js',
-        'tests/test_loader.js'
-      ],
+      test_page: 'tmp/result/tests/index.html',
+      routes: {
+        '/tests/tests.js': 'tmp/result/tests/tests.js',
+        '/assets/app.js': 'tmp/result/assets/app.js',
+        '/assets/templates.js': 'tmp/result/assets/templates.js',
+        '/assets/app.css': 'tmp/result/assets/app.css'
+      },
       launch_in_dev: ['PhantomJS', 'Chrome'],
       launch_in_ci: ['PhantomJS', 'Chrome'],
     }
@@ -32,24 +21,13 @@ module.exports = {
       parallel: 8,
       framework: 'qunit',
       port: (parseInt(process.env.PORT || 7358, 10) + 1),
-      src_files: [
-        'tmp/result/{app,tests}/**/*.{js,coffee,css}',
-        'tmp/result/test/index.html'
-      ],
-      serve_files: [
-        'vendor/loader.js',
-        'vendor/ember-resolver/dist/ember-resolver.js',
-        'vendor/jquery/jquery.js',
-        'vendor/handlebars/handlebars.js',
-        'vendor/ember/ember.js',
-        'vendor/ember-data/ember-data.js',
-        'vendor/ic-ajax/main.js',
-        'tmp/result/assets/templates.js',
-        'tmp/result/assets/app.js',
-        'tmp/transpiled/tests/**/*.js',
-        'tests/test_helper.js',
-        'tests/test_loader.js'
-      ],
+      test_page: 'tmp/result/tests/index.html',
+      routes: {
+        '/tests/tests.js': 'tmp/result/tests/tests.js',
+        '/assets/app.js': 'tmp/result/assets/app.js',
+        '/assets/templates.js': 'tmp/result/assets/templates.js',
+        '/assets/app.css': 'tmp/result/assets/app.css'
+      },
       launch_in_dev: ['PhantomJS',
                      'Chrome',
                      'ChromeCanary',

--- a/testem.json
+++ b/testem.json
@@ -1,18 +1,11 @@
 {
   "framework": "qunit",
-  "src_files": [
-    "vendor/loader.js",
-    "vendor/ember-resolver/dist/ember-resolver.js",
-    "vendor/jquery/jquery.js",
-    "vendor/handlebars/handlebars.js",
-    "vendor/ember/ember.js",
-    "vendor/ember-data/ember-data.js",
-    "vendor/ic-ajax/main.js",
-    "tmp/result/assets/templates.js",
-    "tmp/result/assets/app.js",
-    "tmp/transpiled/tests/**/*.js",
-    "tests/test_helper.js",
-    "tests/test_loader.js"
-  ],
+  "test_page": "tmp/result/tests/index.html",
+  "routes": {
+        "/tests/tests.js": "tmp/result/tests/tests.js",
+        "/assets/app.js": "tmp/result/assets/app.js",
+        "/assets/templates.js": "tmp/result/assets/templates.js",
+        "/assets/app.css": "tmp/result/assets/app.css"
+      },
   "launch_in_dev": ["PhantomJS", "Chrome"]
 }


### PR DESCRIPTION
Instead of specifying the source and serve files, this change
utilizes the test_page option to test index.html directly and load
all the scripts as specified in that file.
- Removes src and serve options from grunt testem task and from
  testem.json
- Adds testem.js to index.html as per
  [testem docs](https://github.com/airportyh/testem#include-snippet)
- Adds routes to testem configuration so that testem can correctly
  locate test files and assets as referenced in index.html

cc @cavneb @stefanpenner 
