### PR TITLE
[#401] Fakes testem.js so that in-browser tests run

### DIFF
--- a/tasks/express-server.js
+++ b/tasks/express-server.js
@@ -52,6 +52,7 @@ module.exports = function(grunt) {
       app.use(static({ urlRoot: '/tests', directory: 'tests' })); // For test_helper.js and test_loader.js
 
       app.use(static({ directory: 'tmp/result' }));
+      app.use(static({ file: 'tests/testem.js' }));
       app.use(static({ file: 'tmp/result/index.html' })); // Gotta catch 'em all
     } else {
       // For `expressServer:dist`

--- a/tests/testem.js
+++ b/tests/testem.js
@@ -1,0 +1,19 @@
+/**
+ * This is dummy file that exists for the sole purpose 
+ * of allowing tests to run directly in the browser as
+ * well as by Testem.
+ *
+ * Testem is configured to run tests directly against 
+ * the test build of index.html, which requires a
+ * snippet to load the testem.js file:
+ * 		<script src="/testem.js"></script>
+ * This has to go after the qunit framework and app
+ * tests are loaded.
+ *
+ * Testem internally supplies this file. However, if you
+ * run the tests directly in the browser (localhost:8000/tests),
+ * this file does not exist.
+ *
+ * Hence the purpose of this fake file. This file is served
+ * directly from the express server to satisify the script load.
+ */


### PR DESCRIPTION
Testem requires a script tag to load /testem.js, which is supplied
by Testem. This file doesn't actually exist on the file system, which
causes localhost:8000/tests to fail with a global failure.

By telling express to serve up a fake testem.js file, the script load
is satisfied, thus making it posible to execute the tests in both
the Testem and direct contexts.
