### PR TITLE
Fixes URL routing

### DIFF
--- a/tasks/express-server.js
+++ b/tasks/express-server.js
@@ -52,7 +52,7 @@ module.exports = function(grunt) {
       app.use(static({ urlRoot: '/tests', directory: 'tests' })); // For test_helper.js and test_loader.js
 
       app.use(static({ directory: 'tmp/result' }));
-      app.use(static({ file: 'tests/testem.js' }));
+      app.use(static({ urlRoot: '/testem.js', directory: 'tests' }));
       app.use(static({ file: 'tmp/result/index.html' })); // Gotta catch 'em all
     } else {
       // For `expressServer:dist`


### PR DESCRIPTION
The way the static middleware works, to serve a file but also let
index.html catch everything, the urlRoot option must be used in
conjunction with the directory option.

Previously, the introduction of faking the testem.js file broke
location history routing, because all routes were caught by the
testem fake file. This patch serves the fake file for the URL, but
also preserves the index.html catch all.
