### PR TITLE
Update "Managing Dependencies" page with more info about using `bower.js`

### DIFF
--- a/guides/dependencies.md
+++ b/guides/dependencies.md
@@ -3,10 +3,14 @@ layout: default
 title: "Managing Dependencies"
 permalink: dependencies.html
 ---
-### Managing Dependencies 
-Ember App Kit uses bower for dependency management. Bower configuration file is located at the root of your EAK project `../bower.json` 
+Ember App Kit uses [Bower](http://bower.io/) for dependency management.
 
-Dependencies can be installed by executing: 
-`bower install`
+### Bower Configuration
 
-Further documentation about bower is available at their [official documentation page](http://bower.io/).
+The Bower configuration file, `bower.json`, is located at the root of your EAK project, and lists the dependencies for your project.  Changes to your dependencies should be managed through this file, rather than manually installing packages individually.
+
+Executing `bower install` will install all of the dependencies listed in `bower.json` in one step.
+
+EAK is configured to have git ignore your `vendor` directory by default.  Using the Bower configuration file allows collaborators to fork your repo and get their dependencies installed locally by executing `bower install` themselves.
+
+Further documentation about Bower is available at their [official documentation page](http://bower.io/).


### PR DESCRIPTION
I had to resist doing a whole Bower primer, regarding pruning and updating, etc.  I can add that in if desired.

I wasn't sure why the config file was originally listed as `../bower.json`, but I can change it back if there was a good reason.
