### PR TITLE
[#417] Returns 404 for un-handled resources

### DIFF
--- a/tasks/express-server.js
+++ b/tasks/express-server.js
@@ -99,7 +99,6 @@ module.exports = function(grunt) {
         if (options.ignoredFileExtensions) {
           if (options.ignoredFileExtensions.test(req.path)) {
             res.send(404, {error: 'Resource not found'});
-            next('Resource not found');
             return; // Do not serve index.html
           }
         }


### PR DESCRIPTION
To use, add ignoredFileExtensions key to static():

``` JS
app.use(static({ file: 'tmp/result/index.html', ignoredFileExtensions: /\.\w{1,5}$/ }));
```

Middleware is processed sequentially, so this should be the last call
to catch non-existent asset files. All other paths continue back to
index.html to be handled by the Ember router.
- Adds another option, ignoredFileExtensions the static middleware
  function, which allows you to specify a regex to capture resource
  paths that should return a 404.
- Adds a check in static() for ignoredFileExtensions key that tests
  the regex against the request path for a matching file ending.
  If matched, then it sends a 404 error and does not serve the
  index.html file.
