### PR TITLE
Allow clearing the registry.

### DIFF
--- a/vendor/loader.js
+++ b/vendor/loader.js
@@ -8,7 +8,6 @@ var define, requireModule, require, requirejs;
   };
 
   requirejs = require = requireModule = function(name) {
-  requirejs._eak_seen = registry;
 
     if (seen.hasOwnProperty(name)) { return seen[name]; }
     seen[name] = {};
@@ -50,4 +49,10 @@ var define, requireModule, require, requirejs;
       return parentBase.join("/");
     }
   };
+  requirejs._eak_seen = registry;
+  requirejs.clear = function(){
+    requirejs._eak_seen = registry = {};
+    seen = {};
+  };
+
 })();


### PR DESCRIPTION
This is useful for testing custom lookups in the resolver itself. I would much
prefer to keep this the same everywhere and it currently seems that the
canonical `loader.js` is here in EAK.

Also, moved the definition of `requirejs._eak_seen` to be outside of the
`requirejs` function. I am not sure why we would want to reset it everytime
that we call require.
