### PR TITLE
Merge `custom-options` to allow additional tasks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -48,7 +48,8 @@ module.exports = function(grunt) {
   var Helpers = require('./tasks/helpers'),
       filterAvailable = Helpers.filterAvailableTasks,
       _ = grunt.util._,
-      path = require('path');
+      path = require('path'),
+      loadGruntConfig = require('load-grunt-config');
 
   Helpers.pkg = require("./package.json");
 
@@ -58,23 +59,28 @@ module.exports = function(grunt) {
 
   // Loads task options from `tasks/options/` and `tasks/custom-options`
   // and loads tasks defined in `package.json`
-  var config = _.extend({},
-    require('load-grunt-config')(grunt, {
-        configPath: path.join(__dirname, 'tasks/options'),
-        loadGruntTasks: false,
-        init: false
-      }),
-    require('load-grunt-config')(grunt, { // Custom options have precedence
-        configPath: path.join(__dirname, 'tasks/custom-options'),
-        init: false
-      })
+  var config = _.merge(
+    loadGruntConfig(grunt, {
+      configPath: path.join(__dirname, 'tasks/options'),
+      init: false
+    }),
+
+    // Custom options have precedence
+    loadGruntConfig(grunt, {
+      configPath: path.join(__dirname, 'tasks/custom-options'),
+      init: false
+    })
   );
 
   grunt.loadTasks('tasks'); // Loads tasks in `tasks/` folder
 
   config.env = process.env;
 
-  
+  // Debug task to log the used Grunt configuration
+  grunt.registerTask('_log:config', "Write the used Grunt configuration to tmp/grunt_config.js", function() {
+    grunt.file.write("tmp/grunt_config.js", JSON.stringify(config, null, 2));
+    grunt.log.writeln("Used Grunt configuration written to tmp/grunt_config.js");
+  });
 
 
   // App Kit's Main Tasks


### PR DESCRIPTION
Changes in 2ae12fb9d2b9169a53dc5748fe9ce66e52bcbdbf and fe0f687d0958a508bf2e8118c17a8f419af5277d  made it possible to specify custom grunt configurations. The idea is to specify custom tasks inside the `tasks/custom-options` folder. For example there are already tasks for the `copy` plugin defined in `tasks/options/copy.js`, but we can specify a new task in `tasks/custom-options/copy.js`:

``` javascript
module.exports = {
  custom_copy_task: { ... }
}
```

The problem with the current implementation is that the custom `copy` configuration would completely overwrite the already defined one. That's because Lo-Dash's `_.extend` is used, which [_... will overwrite property assignments of previous sources_](http://lodash.com/docs#assign).

By using `_.merge` instead, the properties are merged since it [_... recursively merges own enumerable properties of the source object(s), that don't resolve to undefined into the destination object_](http://lodash.com/docs#merge) so it is possible to specify a custom configuration and preserve the existing one, as illustrated with the following simple example:

``` javascript
var a = { first: { a: "a" } };
var b = { first: { b: "b" } };

grunt.file.write("tmp/extend.js", JSON.stringify(_.extend({}, a, b), null, 2));
grunt.file.write("tmp/merge.js", JSON.stringify(_.merge({}, a, b), null, 2));
```

`diff tmp/extend.js tmp/merge.js --side-by-side` results in the following diff:

```
{                          {
  "first": {                 "first": {
                   >           "a": "a",
    "b": "b"                   "b": "b"
  }                          }
}                          }
```

A task `_log:config` has been added which writes the used grunt configuration to `tmp/grunt_config.js` so the resulting configuration can be inspected to check if the custom tasks are configured correctly.

---

If this PR is merged, I'll give the `gh-pages` branch some :heart: and add documentation on how to specify custom tasks.

cc @MajorBreakfast @Pradeek
