### PR TITLE
Update to Ember 1.4.0-beta.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,13 +4,13 @@
     "handlebars": "~1.1.2",
     "jquery": "~1.9.1",
     "qunit": "~1.12.0",
-    "ember": "~1.3.0-beta.4",
+    "ember": "~1.4.0-beta.2",
     "ember-data": "~1.0.0-beta.4",
     "ember-resolver": "git://github.com/stefanpenner/ember-jj-abrams-resolver.git#master",
     "ic-ajax": "~0.2",
     "ember-testing-httpRespond": "~0.1.1"
   },
   "resolutions": {
-    "ember": "~1.3.0-beta.4"
+    "ember": "~1.4.0-beta.2"
   }
 }


### PR DESCRIPTION
Ember 1.3.1 has an issue that prevents loading/error substates from working properly (see [detailed comment](https://github.com/stefanpenner/ember-jj-abrams-resolver/issues/13#issuecomment-32726797)).

This was fixed upstream and is working properly on Ember 1.4.0-beta.2.
