### PR TITLE
Force testem to rerun tests after any files in tmp/result are changed.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -128,6 +128,9 @@ module.exports = function(grunt) {
   grunt.registerTask('test:browsers', "Run your app's tests in multiple browsers (see tasks/options/testem.js for configuration).", [
                      'clean:debug', 'build:debug', 'testem:ci:browsers' ]);
 
+  grunt.registerTask('test:server', "Alias to `testem:run:basic`. Be sure to install testem first using `npm install -g testem`", [
+                     'testem:run:basic' ]);
+
   // Worker tasks
   // =================================
 

--- a/tasks/options/testem.js
+++ b/tasks/options/testem.js
@@ -12,6 +12,9 @@ module.exports = {
         '/assets/templates.js': 'tmp/result/assets/templates.js',
         '/assets/app.css': 'tmp/result/assets/app.css'
       },
+      src_files: [
+        'tmp/result/**/*.js'
+      ],
       launch_in_dev: ['PhantomJS', 'Chrome'],
       launch_in_ci: ['PhantomJS', 'Chrome'],
     }
@@ -28,6 +31,9 @@ module.exports = {
         '/assets/templates.js': 'tmp/result/assets/templates.js',
         '/assets/app.css': 'tmp/result/assets/app.css'
       },
+      src_files: [
+        'tmp/result/**/*.js'
+      ],
       launch_in_dev: ['PhantomJS',
                      'Chrome',
                      'ChromeCanary',

--- a/testem.json
+++ b/testem.json
@@ -2,10 +2,13 @@
   "framework": "qunit",
   "test_page": "tmp/result/tests/index.html",
   "routes": {
-        "/tests/tests.js": "tmp/result/tests/tests.js",
-        "/assets/app.js": "tmp/result/assets/app.js",
-        "/assets/templates.js": "tmp/result/assets/templates.js",
-        "/assets/app.css": "tmp/result/assets/app.css"
-      },
+    "/tests/tests.js": "tmp/result/tests/tests.js",
+    "/assets/app.js": "tmp/result/assets/app.js",
+    "/assets/templates.js": "tmp/result/assets/templates.js",
+    "/assets/app.css": "tmp/result/assets/app.css"
+  },
+  "src_files": [
+    "tmp/result/**/*.js"
+  ],
   "launch_in_dev": ["PhantomJS", "Chrome"]
 }


### PR DESCRIPTION
Fixes issue 392 in that by running `grunt test:server` in another terminal after the `grunt server` has been run, the changed test files will be watched and tests will trigger on changes.
