### PR TITLE
imagemin should not empty files if run repeatedly

### DIFF
--- a/tasks/options/imagemin.js
+++ b/tasks/options/imagemin.js
@@ -1,5 +1,8 @@
 module.exports = {
   dist: {
+    options: {
+      cache: false
+    },
     files: [{
       expand: true,
       cwd: 'tmp/result',


### PR DESCRIPTION
There is an active bug in imagemin where if you run the task repeatedly it can start outputting empty files. Currently, the easiest way to get around it is to set the cache option to false.

https://github.com/gruntjs/grunt-contrib-imagemin/issues/140
