### PR TITLE
No relative paths in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
     "test": "test"
   },
   "scripts": {
-    "start": "./node_modules/.bin/grunt server",
-    "build": "./node_modules/.bin/grunt build:debug",
-    "test": "./node_modules/.bin/grunt test:ci",
-    "postinstall": "./node_modules/.bin/bower install"
+    "start": "grunt server",
+    "build": "grunt build:debug",
+    "test": "grunt test:ci",
+    "postinstall": "bower install"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Relative paths are not needed. npm uses local packages on mac and windows without the use of relative paths as demonstrated in https://github.com/stefanpenner/ember-app-kit/commit/32c7790c7564d0d194393a53907618ad4a0b0e61

The removal of the relative paths is necessary because on windows it won't work otherwise.
