### PR TITLE
Remove brittle tests

### DIFF
--- a/tests/acceptance/component_test.js
+++ b/tests/acceptance/component_test.js
@@ -10,7 +10,7 @@ module('Acceptances - Component', {
 });
 
 test('component output is rendered', function(){
-  expect(3);
+  expect(2);
 
   visit('/component-test').then(function(){
     var list = find('.pretty-color');


### PR DESCRIPTION
- Page Title is not an output of the component.

What's going on is that we have a duplicate, out-of-scope test inside of the components, one that belongs to index_test.js. I'm writing a guide at http://github.com/ulisesrmzroche/ember-app-kit-in-depth
