### PR TITLE
Replace JSHint `predef` with `globals`

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,14 +1,14 @@
 {
-  "predef": [
-    "document",
-    "window",
-    "location",
-    "setTimeout",
-    "Ember",
-    "Em",
-    "DS",
-    "$"
-  ],
+  "globals": {
+    "document": true,
+    "window": true,
+    "location": true,
+    "setTimeout": true,
+    "Ember": true,
+    "Em": true,
+    "DS": true,
+    "$": true
+  },
   "node" : false,
   "browser" : false,
   "boss" : true,


### PR DESCRIPTION
It looks like `predef` was deprecated in favor of `globals` quite a while ago.

For reference:
- https://github.com/jquery/jquery/pull/1185,
- https://github.com/gruntjs/grunt-contrib-jshint/blob/1fb8000baccb1fedf51c55cdac56f86cac023ad1/tasks/jshint.js#L28-L34
