### PR TITLE
Fixing a documentation bug regarding nested route naming conventions.

### DIFF
--- a/guides/naming-conventions.md
+++ b/guides/naming-conventions.md
@@ -82,7 +82,7 @@ If your filename has an underscore in it, we can reference it using the followin
 
 {% highlight sh %}
 // controller/posts/comment_thread.js -> controller:posts/comment-thread  
-var CommentThreadPostsController = Ember.Controller.extend();
+var PostsCommentThreadController = Ember.Controller.extend();
 
-export default CommentThreadPostsController;
+export default PostsCommentThreadController;
 {% endhighlight %}


### PR DESCRIPTION
As I understand it, `controller/posts/comment_thread.js` should return `PostsCommentThreadController`; the docs had the folder namespace and class name reversed.
