### PR TITLE
Improved Test Helpers

### DIFF
--- a/tests/helpers/module_for.js
+++ b/tests/helpers/module_for.js
@@ -1,0 +1,134 @@
+var __testing_context__;
+
+function defaultSubject(factory, options) {
+  return factory.create(options);
+}
+
+export function moduleFor(fullName, description, callbacks, delegate) {
+  callbacks = callbacks || { };
+
+  var needs = [fullName].concat(callbacks.needs || []);
+  var container = isolatedContainer(needs);
+
+  callbacks.subject = callbacks.subject || defaultSubject;
+
+  callbacks.setup    = callbacks.setup    || function() { };
+  callbacks.teardown = callbacks.teardown || function() { };
+
+  function factory() {
+    return container.lookupFactory(fullName);
+  }
+
+  function subject(options) {
+    return callbacks.subject(factory(), options);
+  }
+
+  __testing_context__ = {
+    container: container,
+    subject: subject,
+    factory: factory,
+    __setup_properties__: callbacks
+  };
+
+  if (delegate) {
+    delegate(factory(), container, __testing_context__);
+  }
+
+  var context = __testing_context__;
+  var _callbacks = {
+    setup: function(){
+      buildContextVariables(context);
+      callbacks.setup.call(context, container);
+    },
+    teardown: function(){
+      Ember.run(function(){
+        container.destroy();
+        // destroy all cached variables
+      });
+
+      Ember.$('#ember-testing').empty();
+      // maybe destroy all the add-hoc objects
+
+      callbacks.teardown(container);
+    }
+  };
+
+  module(description, _callbacks);
+}
+
+// allow arbitrary named factories, like rspec let
+function buildContextVariables(context) {
+  var cache = { };
+  var callbacks = context.__setup_properties__;
+  var factory = context.factory;
+  var container = context.container;
+
+  Ember.keys(callbacks).filter(function(key){
+    // ignore the default setup/teardown keys
+    return key !== 'setup' && key && 'teardown';
+  }).forEach(function(key){
+    context[key] = function(options) {
+      if (cache[key]) {
+        return cache[key];
+      }
+
+      var result = callbacks[key](factory(), options, container);
+      cache[key] = result;
+      return result;
+    };
+  });
+}
+
+export function test(testName, callback) {
+  var context = __testing_context__; // save refence
+
+  function wrapper() {
+    var result = callback.call(context);
+
+    function failTestOnPromiseRejection(reason) {
+      ok(false, reason);
+    }
+
+    Ember.run(function(){
+      stop();
+      Ember.RSVP.Promise.cast(result)['catch'](failTestOnPromiseRejection)['finally'](start);
+    });
+  }
+
+  QUnit.test(testName, wrapper);
+}
+
+export function moduleForModel(name, description, callbacks) {
+  moduleFor('model:' + name, description, callbacks, function(factory, container, context) {
+    // custom model specific awesomeness
+    container.register('store:main', DS.Store);
+    container.register('adapter:application', DS.FixtureAdapter);
+
+    context.__setup_properties__.store = function(){
+      return container.lookup('store:main');
+    };
+
+    if (context.__setup_properties__.subject === defaultSubject) {
+      context.__setup_properties__.subject = function(options) {
+        return Ember.run(function() {
+          return container.lookup('store:main').createRecord(name, options);
+        });
+      };
+    }
+  });
+}
+
+export function moduleForComponent(name, description, callbacks) {
+  // just a spike...
+  moduleFor('component:' + name, description, callbacks, function(factory, container, context) {
+
+    context.__setup_properties__.$ = function(selector) {
+      var view = Ember.run(function(){
+        return context.subject().appendTo(Ember.$('#ember-testing')[0]);
+      });
+
+      return view.$();
+    };
+  });
+}
+

--- a/tests/unit/components/pretty_color_test.js
+++ b/tests/unit/components/pretty_color_test.js
@@ -1,0 +1,26 @@
+import { test , moduleForComponent } from 'appkit/tests/helpers/module_for';
+
+moduleForComponent('pretty-color');
+
+test("changing colors", function(){
+  var component = this.subject();
+
+  Ember.run(function(){
+    component.set('name','red');
+  });
+
+  // first call to $() renders the component.
+  equal(this.$().attr('style'), 'color: red;');
+
+  Ember.run(function(){
+    component.set('name', 'green');
+  });
+
+  equal(this.$().attr('style'), 'color: green;');
+});
+
+
+test("className", function(){
+  // first call to this.$() renders the component.
+  ok(this.$().is('.pretty-color'));
+});

--- a/tests/unit/routes/index_test.js
+++ b/tests/unit/routes/index_test.js
@@ -1,21 +1,13 @@
+import { test , moduleFor } from 'appkit/tests/helpers/module_for';
+
 import Index from 'appkit/routes/index';
 
-var route;
-module("Unit - IndexRoute", {
-  setup: function(){
-    var container = isolatedContainer([
-      'route:index'
-    ]);
-
-    route = container.lookup('route:index');
-  }
-});
+moduleFor('route:index', "Unit - IndexRoute");
 
 test("it exists", function(){
-  ok(route);
-  ok(route instanceof Index);
+  ok(this.subject() instanceof Index);
 });
 
 test("#model", function(){
-  deepEqual(route.model(), ['red', 'yellow', 'blue']);
+  deepEqual(this.subject().model(), ['red', 'yellow', 'blue']);
 });


### PR DESCRIPTION
Although ember has pretty good architecture that facilitates 
good testing, for some things such as components and ember data models,
it can be tricky to figure out how to even get started testing.

Within ember apps, we tend to use context specific naming conventions
such as this.store(<model-name>), or needs[ <controller-name>], why do
we need to change this convention for our testing.

Also, although QUnit provides a battle tested testing framework
some conventions are pretty bar bone. Async testing, management of
test run specific properties, all leave much to be desired.

Async testing:

Currently, patterns such as the following might be possible.

``` js
test("foo", function(){

  stop();
  somethingAsync().then(function(){
    start();
    ok(true, '');
  });
})
```

But what if simply returning a promise to the callback
handled the start/stop/timeout book keeping for us?

Bonus: what if when the test framework detected a returned
promise, it also asserted that it must settled fulfilled.

``` js
test("foo", function(){
  return somethingAsync().then(function(){
    ok(true, 'something important');
  });
})
```

It is common for your tests to have various variables constructor
During the setup and teardown phase of our tests. Unfortunately,
sometimes its common to leak them by accident, or not tear them down.

Such as.

``` js
var foo, bar, baz;

module("testing the thing", {
  setup: function() {
    foo = Ember.Object.create();
    bar = Ember.Object.create(); 
  },

  teardown: function() {
    foo = null;
    bar = null;
  }
});

test("a test run", function(){
  ok(foo);
  equal(foo, bar);
});
```

So instead, lets let the test framework handle the hard work.

``` js

moduleFor('controller:bar', 'testing the thing', {
  setup: function(factory, container) {
    factory   // => factoryFor controller:bar
    container // => container for injections to be specified.
  },
  // setup: still exists if you need;
  foo: function() {
    return Ember.Object.create();
  },
  bar: function() {
    return Ember.Object.create();
  }
  // teardown: still exists if you need,
  // but cleanup happens automatically.
});

test("a test run", function() {
  // these variables  are lazily instantiated, and cached per test run
  var foo = this.foo();
  var bar = this.bar();

  var controller = this.subject(); // instance of controller:bar

  ok(foo);
  equal(foo, bar);
});
```

component example:

``` js
moduleForComponent('foo');

test("testing foo focuses on entry", function(){

  var component = this.subject();

  // component is rendered the first time we invoke `this.$()`
  // as that is the first time we are inspecting the DOM.
  ok(this.$().is(':focus'));
  ok(component.$().is(':focus'));
});
```

extensibility:

Currently `moduleFor` and `test` are the foundational api's

the first level of configuration is via the module hash

``` js
moduleFor('controller:foo', 'description', {
  subject: function(factory, options) {
    return factory.create(options); // override the default "subject"
  }, 
  setup: function(container) {
    // register factories or injection rules on the container
  },  
  bar: function() { }, // other managed variables
  baz: function() { }
});
```

the second is by specifying a custom `moduleForHelper`, this API and functionality
is still in its infancy so expect it to change some, but an example is the implementation of moduleForModel:

``` js
function moduleForModel(name, description, callbacks) {
  moduleFor('model:' + name, description, callbacks, function(factory, container, context) {
    container.register('store:main', DS.Store);
    container.register('adapter:application', DS.FixtureAdapter);

    context.__setup_properties__.store = function () {
      return container.lookup('store:main');
    }
  }
}
```

paired with @hjdavid
high level ideas derived from conversation with @tomdale + @wycats
