### PR TITLE
Added call to container.reset() in teardown() function

### DIFF
--- a/tests/helpers/module_for.js
+++ b/tests/helpers/module_for.js
@@ -44,6 +44,7 @@ export function moduleFor(fullName, description, callbacks, delegate) {
       Ember.run(function(){
         container.destroy();
         // destroy all cached variables
+        container.reset();
       });
 
       Ember.$('#ember-testing').empty();


### PR DESCRIPTION
Added call to container.reset() in teardown() function to avoid 'calling set on destroyed object' errors
