### PR TITLE
add support to change api prefix (from the /api default)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "namespace": "appkit",
   "APIMethod": "stub",
   "proxyURL": "http://localhost:8000",
+  "proxyPath": "/api",
   "version": "0.0.0",
   "private": true,
   "directories": {

--- a/tasks/express-server.js
+++ b/tasks/express-server.js
@@ -30,11 +30,12 @@ module.exports = function(grunt) {
       app.use(express.urlencoded());
       require('../api-stub/routes')(app);
     } else if (proxyMethod === 'proxy') {
-      var proxyURL = grunt.config('express-server.options.proxyURL');
-      grunt.log.writeln('Proxying API requests to: ' + proxyURL);
+      var proxyURL = grunt.config('express-server.options.proxyURL'),
+          proxyPath = grunt.config('express-server.options.proxyPath') || '/api';
+      grunt.log.writeln('Proxying API requests matching ' + proxyPath + '/* to: ' + proxyURL);
 
       // Use API proxy
-      app.all('/api/*', passThrough(proxyURL));
+      app.all(proxyPath + '/*', passThrough(proxyURL));
     }
 
     if (target === 'debug') {

--- a/tasks/options/express-server.js
+++ b/tasks/options/express-server.js
@@ -3,6 +3,7 @@ var grunt = require('grunt');
 module.exports = {
 	options: {
 		APIMethod: "<%= package.APIMethod %>",		// stub or proxy
-		proxyURL: "<%= package.proxyURL %>"			// URL to the API server, if using APIMethod: 'proxy'
+		proxyURL: "<%= package.proxyURL %>",		// URL to the API server, if using APIMethod: 'proxy'
+		proxyPath: "<%= package.proxyPath %>"		// path for the API endpoints, default is '/api', if using APIMethod: 'proxy'
 	}
 };


### PR DESCRIPTION
I've run into this use case today as my APIs are  not under `/api`

let me know if this could work or if I've missed something :)
