### PR TITLE
assign application parameters via config files

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -1,12 +1,14 @@
 import Resolver from 'resolver';
 
+var params = window.ENV.ApplicationParams;
+
 var App = Ember.Application.extend({
-  LOG_ACTIVE_GENERATION: true,
-  LOG_MODULE_RESOLVER: true,
-  LOG_TRANSITIONS: true,
-  LOG_TRANSITIONS_INTERNAL: true,
-  LOG_VIEW_LOOKUPS: true,
-  modulePrefix: 'appkit', // TODO: loaded via config
+  LOG_ACTIVE_GENERATION: params.LOG_ACTIVE_GENERATION,
+  LOG_MODULE_RESOLVER: params.LOG_MODULE_RESOLVER,
+  LOG_TRANSITIONS: params.LOG_TRANSITIONS,
+  LOG_TRANSITIONS_INTERNAL: params.LOG_TRANSITIONS_INTERNAL,
+  LOG_VIEW_LOOKUPS: params.LOG_VIEW_LOOKUPS,
+  modulePrefix: params.modulePrefix,
   Resolver: Resolver['default']
 });
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -8,3 +8,6 @@
 // window.ENV = {FEATURES: {'with-controller': true}};
 
 window.ENV = {};
+window.ENV.ApplicationParams = {
+  modulePrefix: 'appkit'
+}

--- a/config/environments/development.js
+++ b/config/environments/development.js
@@ -4,3 +4,9 @@
 // endpoint in development than in production.
 //
 // window.ENV.public_key = '123456'
+
+window.ENV.ApplicationParams.LOG_ACTIVE_GENERATION = true;
+window.ENV.ApplicationParams.LOG_MODULE_RESOLVER = true;
+window.ENV.ApplicationParams.LOG_TRANSITIONS = true;
+window.ENV.ApplicationParams.LOG_TRANSITIONS_INTERNAL = true;
+window.ENV.ApplicationParams.LOG_VIEW_LOOKUPS = true;

--- a/config/environments/production.js
+++ b/config/environments/production.js
@@ -4,3 +4,9 @@
 // endpoint in development than in production.
 //
 // window.ENV.public_key = '123456'
+
+window.ENV.ApplicationParams.LOG_ACTIVE_GENERATION = false;
+window.ENV.ApplicationParams.LOG_MODULE_RESOLVER = false;
+window.ENV.ApplicationParams.LOG_TRANSITIONS = false;
+window.ENV.ApplicationParams.LOG_TRANSITIONS_INTERNAL = false;
+window.ENV.ApplicationParams.LOG_VIEW_LOOKUPS = false;

--- a/config/environments/test.js
+++ b/config/environments/test.js
@@ -4,3 +4,9 @@
 // endpoint in test than in production.
 //
 // window.ENV.public_key = '123456'
+
+window.ENV.ApplicationParams.LOG_ACTIVE_GENERATION = true;
+window.ENV.ApplicationParams.LOG_MODULE_RESOLVER = true;
+window.ENV.ApplicationParams.LOG_TRANSITIONS = true;
+window.ENV.ApplicationParams.LOG_TRANSITIONS_INTERNAL = true;
+window.ENV.ApplicationParams.LOG_VIEW_LOOKUPS = true;


### PR DESCRIPTION
Took a stab at using config files to assign application parameters. Mainly just trying move the conversation on this. Some thoughts:
- it would be more elegant to extend a parameters object than assigning values by reference, but that would create a more substantial style difference.
  `javascript
  var App = Ember.Application.extend(window.ENV.CONFIG, {});
  `
- modulePrefix only needs to be defined once. Maybe that doesn't belong in a config file.

Split from #468
