### PR TITLE
Testing: use fullName if module doesn't have description

### DIFF
--- a/tests/helpers/module_for.js
+++ b/tests/helpers/module_for.js
@@ -55,7 +55,7 @@ export function moduleFor(fullName, description, callbacks, delegate) {
     }
   };
 
-  module(description, _callbacks);
+  module(description || fullName, _callbacks);
 }
 
 // allow arbitrary named factories, like rspec let


### PR DESCRIPTION
When a module has a `fullName` but not a `description`, it is is `undefined` in the module list.

An example is here: https://github.com/stefanpenner/ember-app-kit/blob/master/tests/unit/components/pretty_color_test.js#L3
