### PR TITLE
Fixes for "Uncaught TypeError..." message 

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -99,7 +99,12 @@
 
   <!-- @if tests=false -->
   <script>
-    window.App = require('appkit/app')["default"].create();
+    (function(require, window){
+      var fn = require('appkit/app')["default"]["create"];
+      if(typeof fn === 'function') {
+          window.App = fn();
+      }
+    }(require, window));
   </script>
   <!-- @endif -->
 


### PR DESCRIPTION
I was getting over and over again this error message `"Uncaught TypeError: Object [object Object] has no method 'create'"` with the latest eak. I'm not sure if it's only my problem, but this small change fixed it. If you want to consider it, I'd like to get this merged :+1:
