### PR TITLE
Add module import validation

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -193,6 +193,8 @@ module.exports = function(grunt) {
   grunt.registerTask('buildScripts', filterAvailable([
                      'jshint:app',
                      'jshint:tests',
+                     'validate-imports:app',
+                     'validate-imports:tests',
                      'coffee',
                      'emberscript',
                      'copy:javascriptToTmp',

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "loom-generators-ember-appkit": "~1.0.2",
     "originate": "~0.1.5",
     "loom": "~3.1.2",
-    "connect-livereload": "~0.3.1"
+    "connect-livereload": "~0.3.1",
+    "grunt-es6-import-validate": "~0.0.4"
   }
 }

--- a/tasks/options/validate-imports.js
+++ b/tasks/options/validate-imports.js
@@ -1,0 +1,44 @@
+var grunt = require('grunt');
+
+module.exports = {
+  options: {
+    whitelist: {
+      resolver: ['default']
+    }
+  },
+  
+  app: {
+    options: {
+      moduleName: function (name) {
+        return grunt.config.process('<%= package.namespace %>/') + name;
+      }
+    },
+    files: [{
+      expand: true,
+      cwd: 'app',
+      src: ['**/*.js']
+    }]
+  },
+
+  tests: {
+    options: {
+      moduleName: function (name) {
+        // Trim of the leading app/ from app modules
+        if (name.slice(0, 4) === 'app/') {
+          name = name.slice(4);
+        }
+        return grunt.config.process('<%= package.namespace %>/') + name;
+      }
+    },
+    // Test files reference app files so we have to make sure we pull in both sets
+    files: [{
+      expand: true,
+      cwd: '.',
+      src: ['tests/**/*.js']
+    }, {
+      expand: true,
+      cwd: '.',
+      src: ['app/**/*.js']
+    }]
+  }
+};


### PR DESCRIPTION
Closes #500
- Add new dev dependency grunt-es6-import-validate
- Add validate-imports run to buildScripts task
- Add configuration in tasks/options/validate-imports.js
- ~~Modify import from 'resolve' statements to be more explicit about
  using require loader.~~
- Using whitelisted 'resolve' module

I had to [modify my es6-import-validate slightly](https://github.com/sproutsocial/es6-import-validate/pull/4) to support the custom named modules you're using, but that was a good feature to add since I'm sure other people will have the same use case.

I tested this locally by running `grunt`,  `grunt server`, `grunt dist` and of course `npm test`.  There are no errors in the console, and it looks like the basic app is showing (though I'll admit I'm not familiar enough with the default state to really know if something is broken).  When testing the `grunt dist` situation I started a basic http server with the `http-server` npm module and verified no errors in console and app rendered.
