### PR TITLE
Fix test loader for dasherized file names.

### DIFF
--- a/tests/test-loader.js
+++ b/tests/test-loader.js
@@ -1,6 +1,6 @@
 // TODO: load based on params
 Ember.keys(requirejs._eak_seen).filter(function(key) {
-  return (/\_test/).test(key);
+  return (/\-test/).test(key);
 }).forEach(function(moduleName) {
   require(moduleName, null, null, true);
 });


### PR DESCRIPTION
Commit 036df2e2c00aee broke the test loader so that no test modules were found or loaded, and no tests run.

Before this commit, a checkout of ember-app-kit runs 0 tests. Now it runs 18.

I don't know how to write a failing test for this, because if the test runner is broken, it won't run :cold_sweat: 
