### PR TITLE
Example model unit tests

### DIFF
--- a/app/models/comment.js
+++ b/app/models/comment.js
@@ -1,0 +1,16 @@
+var Comment = DS.Model.extend({
+  body: DS.attr('string')
+});
+
+Comment.reopenClass({
+  FIXTURES:
+    [{
+      "id": "1",
+      "body": "Rails is unagi"
+    }, {
+      "id": "2",
+      "body": "Omakase O_o"
+    }]
+});
+
+export default Comment;

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -1,0 +1,16 @@
+var Post = DS.Model.extend({
+  title: DS.attr('string'),
+  user: DS.attr('string'),
+  comments: DS.hasMany('comment')
+});
+
+Post.reopenClass({
+  FIXTURES: [{
+    "id": 1,
+    "title": "Rails is omakase",
+    "comments": ["1", "2"],
+    "user" : "dhh"
+  }]
+});
+
+export default Post;

--- a/tests/helpers/module_for.js
+++ b/tests/helpers/module_for.js
@@ -100,6 +100,25 @@ export function test(testName, callback) {
   QUnit.test(testName, wrapper);
 }
 
+export function asyncTest(testName, callback) {
+  var context = __testing_context__; // save refence
+
+  function wrapper() {
+    var result = callback.call(context);
+
+    function failTestOnPromiseRejection(reason) {
+      ok(false, reason);
+    }
+
+    Ember.run(function(){
+      stop();
+      Ember.RSVP.Promise.cast(result)['catch'](failTestOnPromiseRejection)['finally'](start);
+    });
+  }
+
+  QUnit.asyncTest(testName, wrapper);
+}
+
 export function moduleForModel(name, description, callbacks) {
   moduleFor('model:' + name, description, callbacks, function(container, context) {
     // custom model specific awesomeness

--- a/tests/unit/models/comment_test.js
+++ b/tests/unit/models/comment_test.js
@@ -1,0 +1,29 @@
+import { test , asyncTest, moduleForModel } from 'appkit/tests/helpers/module_for';
+import Comment from 'appkit/models/comment';
+
+moduleForModel('comment', '', {
+  needs: ['model:post']
+});
+
+asyncTest("comment is a valid ember-data Model", function () {
+  var store = this.store();
+  Em.run(function (){
+    store.find('comment', 1).then(function (comment) {
+      ok(comment);
+      ok(comment instanceof DS.Model);
+      ok(comment instanceof Comment);
+      start();
+    });
+  });
+});
+
+asyncTest("the store is able to retrieve the fixture data", function () {
+    var store = this.store();
+    Em.run(function (){
+        store.find('comment', 1).then(function (comment) {
+            ok(comment);
+            equal(comment.get('body'), "Rails is unagi");
+            start();
+        });
+    });
+});

--- a/tests/unit/models/post_test.js
+++ b/tests/unit/models/post_test.js
@@ -1,0 +1,30 @@
+import { test, asyncTest, moduleForModel } from 'appkit/tests/helpers/module_for';
+import Post from 'appkit/models/post';
+
+moduleForModel('post', '', {
+    needs: ['model:comment']
+});
+
+asyncTest("Post is a valid ember-data Model", function () {
+  var store = this.store();
+  Em.run(function (){
+    store.find('post', 1).then(function (post) {
+      ok(post);
+      ok(post instanceof DS.Model);
+      ok(post instanceof Post);
+      start();
+    });
+  });
+});
+
+asyncTest("the store is able to retrieve the fixture data", function () {
+  var store = this.store();
+  Em.run(function (){
+    store.find('post', 1).then(function (post) {
+      ok(post);
+      equal(post.get('title'), "Rails is omakase");
+      equal(post.get('user'), 'dhh');
+      start();
+    });
+  });
+});


### PR DESCRIPTION
Added tests example for model tests to match the current EAK module_for layout.
Also added the asyncTest helper to the module_for for use in testing.
