### PR TITLE
Export `ic.ajax` as is from `appkit/utils/ajax`

### DIFF
--- a/app/utils/ajax.js
+++ b/app/utils/ajax.js
@@ -1,4 +1,2 @@
 /* global ic */
-export default function ajax(){
-  return ic.ajax.apply(null, arguments);
-}
+export default ic.ajax;


### PR DESCRIPTION
Without this, properties on the `ic.ajax` function obj are inaccessible.
