### PR TITLE
Watch port collision fix

### DIFF
--- a/tasks/options/watch.js
+++ b/tasks/options/watch.js
@@ -1,6 +1,7 @@
 var Helpers = require('../helpers'),
     filterAvailable = Helpers.filterAvailableTasks,
-    liveReloadPort = parseInt(process.env.PORT || 8000, 10) + 2;
+    LIVERELOAD_PORT = 35729,
+    liveReloadPort = (parseInt(process.env.PORT || 8000, 10) - 8000) + LIVERELOAD_PORT;
 
 var scripts = '{app,tests,config}/**/*.{js,coffee,em}',
     templates = 'app/templates/**/*.{hbs,handlebars,hjs,emblem}',


### PR DESCRIPTION
Fixes watch port collisions when running multiple instances of EAK …
If you have connect-live-reload installed then the custom port number
gets clobbered, resulting in the default watch port always being set.

Changes live reload port to higher to make potential collisions less likely.
Live reload ports are now 35729 + an offset depending on what port is
chosen for the main server.
