### PR TITLE
Fix liveReload port on the express-server

### DIFF
--- a/tasks/express-server.js
+++ b/tasks/express-server.js
@@ -43,7 +43,8 @@ module.exports = function(grunt) {
 
       // Add livereload middleware after lock middleware if enabled
       if (Helpers.isPackageAvailable("connect-livereload")) {
-        app.use(require("connect-livereload")());
+        var liveReloadPort = grunt.config('watch.options.livereload');
+        app.use(require("connect-livereload")({port: liveReloadPort}));
       }
 
       // These three lines simulate what the `copy:assemble` task does


### PR DESCRIPTION
Currently, the 'watch' task computes a port for liveReload to run on the express-server. However, the 'connect-livereload' module inside of the express-server doesn't have access to that computed port, so the html that is rendered uses the wrong port if process.env.PORT is changed to anything other than the default 8000.
