### PR TITLE
Add jshint node:true comment to Gruntfile

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,3 +1,5 @@
+// jshint node:true
+
 module.exports = function(grunt) {
   // To support Coffeescript, SASS, LESS and others, just install
   // the appropriate grunt package and it will be automatically included


### PR DESCRIPTION
This keeps jshint from complaining about some of the node globals used in Gruntfile.js (eg: require).
