### PR TITLE
validate-imports is missing a whitelist entry for moduleForModel

### DIFF
--- a/tasks/options/validate-imports.js
+++ b/tasks/options/validate-imports.js
@@ -4,7 +4,7 @@ module.exports = {
   options: {
     whitelist: {
       'ember/resolver': ['default'],
-      'ember-qunit': ['moduleForComponent', 'moduleFor', 'test', 'default'],
+      'ember-qunit': ['moduleForComponent', 'moduleForModel', 'moduleFor', 'test', 'default'],
     }
   },
 


### PR DESCRIPTION
While writing a model test I ran into this error:

```
Running "validate-imports:tests" (validate-imports) task
>> appkit/tests/unit/models/page-test: Cannot find "moduleForModel" export for "ember-qunit"

Warning: Validation errors found in modules. Use --force to continue.

Aborted due to warnings.
    Warning:  Use --force to continue.

        Aborted due to warnings.
```

Adding moduleForModel to the whitelist seems to fix it.
