### PR TITLE
Don't use PORT environment variable for grunt-express-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "app-kit",
   "namespace": "appkit",
   "APIMethod": "stub",
+  "expressServerPort": 8000,
   "proxyURL": "http://localhost:8000",
   "proxyPath": "/api",
   "docURL": "http://localhost:8000/docs/index.html",

--- a/tasks/express-server.js
+++ b/tasks/express-server.js
@@ -66,9 +66,9 @@ module.exports = function(grunt) {
       app.use(static({ file: 'dist/index.html', ignoredFileExtensions: /\.\w{1,5}$/ })); // Gotta catch 'em all
     }
 
-    var port = parseInt(process.env.PORT || 8000, 10);
+    var port = parseInt(grunt.config('express-server.options.serverPort') || 8000, 10);
     if (isNaN(port) || port < 1 || port > 65535) {
-      grunt.fail.fatal('The PORT environment variable of ' + process.env.PORT + ' is not valid.');
+      grunt.fail.fatal('The package.json "expressServerPort" variable of ' + port + ' is not valid.');
     }
     app.listen(port);
     grunt.log.ok('Started development server on port %d.', port);

--- a/tasks/options/express-server.js
+++ b/tasks/options/express-server.js
@@ -4,6 +4,7 @@ module.exports = {
 	options: {
 		APIMethod: "<%= package.APIMethod %>",		// stub or proxy
 		proxyURL: "<%= package.proxyURL %>",		// URL to the API server, if using APIMethod: 'proxy'
-		proxyPath: "<%= package.proxyPath %>"		// path for the API endpoints, default is '/api', if using APIMethod: 'proxy'
+		proxyPath: "<%= package.proxyPath %>",		// path for the API endpoints, default is '/api', if using APIMethod: 'proxy'
+		serverPort: "<%= package.expressServerPort %>",	// the port that express server runs on, default is 8000 if unset
 	}
 };

--- a/tasks/options/watch.js
+++ b/tasks/options/watch.js
@@ -1,7 +1,7 @@
 var Helpers = require('../helpers'),
     filterAvailable = Helpers.filterAvailableTasks,
     LIVERELOAD_PORT = 35729,
-    liveReloadPort = (parseInt(process.env.PORT || 8000, 10) - 8000) + LIVERELOAD_PORT;
+    liveReloadPort = (parseInt("<%= package.expressServerPort %>" || 8000, 10) - 8000) + LIVERELOAD_PORT;
 
 var docs = '{app}/**/*.{js,coffee,em}',
     scripts = '{app,tests,config}/**/*.{js,coffee,em}',


### PR DESCRIPTION
This came out of setting up `ember-app-kit` for [FreshBooks](http://www.freshbooks.com/)' development & builds infrastructure and colliding with another project's port.

Setting the environment variables for port configurations feels a bit odd and is obscure to locate. In addition, `PORT` is a very common environment variable that may collide with others.

By defining it explicitly in package.json, the user is able to quickly and easily change the port and check it into source control.

I explicitly left `process.env.PORT` alone in `tasks/options/testem.js` as I'm unsure if that's specific/relevant to grunt-express-server or not. It should probably be defined as `testemPort` in `package.json` anyhow. Thoughts?
