### PR TITLE
Bumps bower version to 1.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "express": "~3.4.8",
     "lockfile": "~0.4.2",
-    "bower": "~1.2.7",
+    "bower": "~1.3.2",
     "grunt": "~0.4.2",
     "grunt-cli": "~0.1.9",
     "load-grunt-config": "~0.7.0",


### PR DESCRIPTION
The main reason for upgrading is to use the 1.3.x branch and avoid the
1.2.8 release which is buggy (`ENOENT` error during `bower install`).

See https://github.com/bower/bower/issues/991

cc @mattmcginnis
