### PR TITLE
The JJ Abrams resolver is registered at 'resolver' not 'ember/resolver'

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -1,4 +1,4 @@
-import Resolver from 'ember/resolver';
+import Resolver from 'resolver';
 import loadInitializers from 'ember/load-initializers';
 
 var App = Ember.Application.extend({

--- a/tasks/options/validate-imports.js
+++ b/tasks/options/validate-imports.js
@@ -3,7 +3,7 @@ var grunt = require('grunt');
 module.exports = {
   options: {
     whitelist: {
-      'ember/resolver': ['default'],
+      'resolver': ['default'],
       'ember/load-initializers': ['default'],
       'ember-qunit': ['moduleForComponent', 'moduleForModel', 'moduleFor', 'test', 'default'],
     }

--- a/tests/helpers/resolver.js
+++ b/tests/helpers/resolver.js
@@ -1,4 +1,4 @@
-import Resolver from 'ember/resolver';
+import Resolver from 'resolver';
 
 var resolver = Resolver.create();
 


### PR DESCRIPTION
Not sure why bower does not fetch the latest off of jj abrams resolver master branch. This causes the AMD identifiers to not match.
