### PR TITLE
File names should contain dashes, not underscores

### DIFF
--- a/guides/naming-conventions.md
+++ b/guides/naming-conventions.md
@@ -177,10 +177,10 @@ export default Ember.Controller.extend({
 {% endraw %}
 {% endhighlight %}
 
-If your filename has an underscore in it, we can reference it using the following technique:
+If your filename has a dash in it, we can reference it using the following technique:
 
 {% highlight sh %}
-// controller/posts/comment_thread.js -> controller:posts/comment-thread
+// controller/posts/comment-thread.js -> controller:posts/comment-thread
 export default Ember.Controller.extend();
 {% endhighlight %}
 


### PR DESCRIPTION
This makes sure #607 actually conforms to the convention (using dasherized file names).
