### PR TITLE
refactored the test loader to iterate once and be a bit more readable

### DIFF
--- a/tests/test-loader.js
+++ b/tests/test-loader.js
@@ -1,6 +1,6 @@
 // TODO: load based on params
-Ember.keys(requirejs._eak_seen).filter(function(key) {
-  return (/\-test/).test(key);
-}).forEach(function(moduleName) {
-  require(moduleName, null, null, true);
+Ember.keys(requirejs.entries).forEach(function(entry) {
+  if ((/\-test/).test(entry)) {
+    require(entry, null, null, true);
+  }
 });


### PR DESCRIPTION
Prevented the test loader from iterating twice (not really a performance win, but still unnecessary work) and made things a bit more readable. `requirejs.entries` and `entry` are easier to understand than `requirejs._eak_seen` and `key` (to me at least). 
