### PR TITLE
Add context to exists helper

### DIFF
--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -7,8 +7,8 @@ require('ember-qunit').setResolver(resolver);
 window.startApp          = require('appkit/tests/helpers/start-app')['default'];
 window.isolatedContainer = require('ember-qunit/isolated-container')['default'];
 
-function exists(selector) {
-  return !!find(selector).length;
+function exists(selector, context) {
+  return !!find(selector, context).length;
 }
 
 function getAssertionMessage(actual, expected, message) {


### PR DESCRIPTION
Checks the existence of an element within the context if provided.
