### PR TITLE
Revert "Remove unnecessary router reopening"

### DIFF
--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -1,4 +1,5 @@
 import Application from 'appkit/app';
+import Router from 'appkit/router';
 
 function startApp(attrs) {
   var App;
@@ -9,6 +10,10 @@ function startApp(attrs) {
     LOG_ACTIVE_GENERATION:false,
     LOG_VIEW_LOOKUPS: false
   }, attrs); // but you can override;
+
+  Router.reopen({
+    location: 'none'
+  });
 
   Ember.run(function(){
     App = Application.create(attributes);


### PR DESCRIPTION
This reverts commit 46040476a75b4470acff131f39a1391f039af422.

As it turns out, `App.setupForTesting`, even though it calls `App.Router.reopen` to set `location: 'none'`, does not affect the routing behavior of the tests. I'm not sure if this is due to the way EAK interacts with the resolver to create its router, or if it is a more ember-y bug. I'm going to look into a PR for ember to ensure that `App.setupForTesting` does change the router either way, but in the meantime this commit should probably be reverted.

If you check out master of EAK and run the tests, specifically test 2 ("Acceptances - Helper"), you'll see the URL changes from http://localhost:8000/tests?testNumber=2 to http://localhost:8000/tests?testNumber=2#/helper-test

![eak-router](https://cloud.githubusercontent.com/assets/2023/2908824/ee1b1f22-d62b-11e3-8eeb-af9779a1fa41.gif)
