### PR TITLE
Migration Guide Update :tada:

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,88 @@ this project has been deprecated in-favour of the ember-cli project:
 * https://github.com/stefanpenner/ember-cli
 * http://iamstef.net/ember-cli
 
+## Migrating to Ember CLI
+
+First, run `npm install -g ember-cli` to install Ember CLI.
+Now, on top of your existing EAK project, run `ember init`. Ember CLI
+will then migrate your project, showing you a diff of its overrides,
+and letting you edit them, as it goes along.
+
+### Ember Init Overrides
+
+* tests/.jshintrc
+* Let ember-cli overwrite this.
+* app/index.html
+* Since managing vendor assets is now handled via the Brocfile, you should let ember-cli overwrite this file.
+* app/app.js
+* Ember Configuration is now handled in the `config` directory.
+* app/router.js
+* The Router's location is now handled via environment configuration.
+Change this to ENV.locationType.
+* app/routes/index.js
+* This will attempt to replace your Index Route with a stub. Usually,
+you wont't want Ember CLI to override this file.
+* Brocfile.js
+* Move your dependencies from app/index.html into this file by calling
+app.import().
+* Example: app.import('vendor/ember-data/ember-data.js')
+* app/templates/application.hbs
+* This will attempt to replace your application template with a stub.
+* app/styles/app.css
+* Another stub.
+* tests/index.html
+* Let ember-cli add this file. Include any test depencies you had in `app/index.html'.
+* bower.json
+* package.json
+
+### Importing Ember and Ember Data
+
+You now have to explicitly import Ember and Ember Data. Add `import Ember from "ember` and
+`import DS from "ember-data"` anywhere you declared a route, controller, model, and so on.
+
+### Migrating your API Stub
+
+To work with the API stub again, run `ember generate api-stub`.
+This command generates a server directory where you can then migrate your routes accordingly.
+
+You may also want to look into [Ember CLI Rest API Blueprint](https://github.com/manuelmitasch/ember-cli-rest-api-blueprint)
+which generates DS.RESTAdapter compatible express routes for a given Model.
+
+### Using The Express Server
+
+The Express server has been exposed and now lives under this directory.
+You can now customize it any way you want, from enhancing the static file server,
+to simply using it as an API stub. You may even develop it further and turn it into a full-stack solution.
+
+### Cleanup
+
+You can remove the Gruntfile and tasks folder since we won't be needing them anymore.
+
+For now, you can check the [app blueprint](https://github.com/stefanpenner/ember-cli/tree/master/blueprints/app/files)
+to see what other files you no longer need.
+
+### Troubleshooting
+
+* Ember CLI now picks up your app namespace. Change the import to
+reference the name of your project.
+* If you never changed your application namespace from the default
+`appkit` then running `ember init` will break any import statements
+you already have
+
+* Index Route doesn't exist
+* You may need to refresh your dependencies. Run `rm -rf npm_modules && npm install && npm
+cache clean && bower install`
+
+* Tests
+* Import `tests/helpers/start-app` into each acceptance test file.
+* `import startApp from 'your-app/tests/helpers/start-app`
+* `resolver` and `startApp` still live in `test/helpers/` but
+`module-for` is now its own package.
+* If you were using ember-testing-httpRespond
+* This is now patched for 1.4+
+* Import it and its dependencies in your Brocfile by using
+`app.import()`
+
 
 
 
@@ -43,88 +125,7 @@ We welcome ideas and experiments.
 - Catch-all `index.html` for easy reloading of pushState router apps
 - Generators via [Loom](https://github.com/cavneb/loom-generators-ember-appkit) (to generate routes, controllers, etc.)
 
-## Migrating to Ember CLI
 
-First, run `npm install -g ember-cli` to install Ember CLI.
-Now, on top of your existing EAK project, run `ember init`. Ember CLI
-will then migrate your project, showing you a diff of its overrides,
-and letting you edit them, as it goes along.
-
-### Ember Init Overrides
-
-* tests/.jshintrc
-  * Let ember-cli overwrite this.
-* app/index.html
-    * Since managing vendor assets is now handled via the Brocfile, you should let ember-cli overwrite this file.
-* app/app.js
-  * Ember Configuration is now handled in the `config` directory.
-* app/router.js
-  * The Router's location is now handled via environment configuration.
-    Change this to ENV.locationType.
-* app/routes/index.js
-  * This will attempt to replace your Index Route with a stub. Usually,
-    you wont't want Ember CLI to override this file.
-* Brocfile.js
-  * Move your dependencies from app/index.html into this file by calling
-    app.import().
-    * Example: app.import('vendor/ember-data/ember-data.js')
-* app/templates/application.hbs
-  * This will attempt to replace your application template with a stub.
-* app/styles/app.css
-  * Another stub.
-* tests/index.html
-  * Let ember-cli add this file. Include any test depencies you had in `app/index.html'.
-* bower.json
-* package.json
-
-
-### Importing Ember and Ember Data
-
-You now have to explicitly import Ember and Ember Data. Add `import Ember from "ember` and
-`import DS from "ember-data"` anywhere you declared a route, controller, model, and so on.
-
-### Migrating your API Stub
-
-To work with the API stub again, run `ember generate api-stub`.
-This command generates a server directory where you can then migrate your routes accordingly.
-
-You may also want to look into [Ember CLI Rest API Blueprint](https://github.com/manuelmitasch/ember-cli-rest-api-blueprint)
-which generates DS.RESTAdapter compatible express routes for a given Model.
-
-### Using The Express Server
-
-The Express server has been exposed and now lives under this directory.
-You can now customize it any way you want, from enhancing the static file server,
-to simply using it as an API stub. You may even develop it further and turn it into a full-stack solution.
-
-### Cleanup
-
-You can remove the Gruntfile and tasks folder since we won't be needing them anymore.
-
-For now, you can check the [app blueprint](https://github.com/stefanpenner/ember-cli/tree/master/blueprints/app/files)
-to see what other files you no longer need.
-
-### Troubleshooting
-
-* Ember CLI now picks up your app namespace. Change the import to
-  reference the name of your project.
-  * If you never changed your application namespace from the default
-    `appkit` then running `ember init` will break any import statements
-     you already have
-
-* Index Route doesn't exist
-  * You may need to refresh your dependencies. Run `rm -rf npm_modules && npm install && npm
-    cache clean && bower install`
-
-* Tests
-  * Import `tests/helpers/start-app` into each acceptance test file.
-    * `import startApp from 'your-app/tests/helpers/start-app`
-  * `resolver` and `startApp` still live in `test/helpers/` but
-    `module-for` is now its own package.
-  * If you were using ember-testing-httpRespond
-    * This is now patched for 1.4+
-    * Import it and its dependencies in your Brocfile by using
-      `app.import()`
 
 ## Special Thanks
 

--- a/README.md
+++ b/README.md
@@ -52,8 +52,7 @@ You now have to explicitly import Ember and Ember Data. Add `import Ember from "
 
 ### Migrating your API Stub
 
-To work with the API stub again, run `ember generate api-stub`.
-This command generates a server directory where you can then migrate your routes accordingly.
+To work with the API stub again, run `ember generate server`. This command generates a server directory for your mocks and proxies where you can then migrate your routes accordingly.
 
 You may also want to look into [Ember CLI Rest API Blueprint](https://github.com/manuelmitasch/ember-cli-rest-api-blueprint)
 which generates DS.RESTAdapter compatible express routes for a given Model.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ this project has been deprecated in-favour of the ember-cli project:
 * https://github.com/stefanpenner/ember-cli
 * http://iamstef.net/ember-cli
 
+
 ## Migrating to Ember CLI
 
 First, run `npm install -g ember-cli` to install Ember CLI.
@@ -38,6 +39,11 @@ app.import().
 * Let ember-cli add this file. Include any test depencies you had in `app/index.html'.
 * bower.json
 * package.json
+
+
+## Ember CLI Migrator
+
+The [Ember CLI Migrator](https://github.com/fivetanley/ember-cli-migrator) will help you migrate your files to the standard ember-cli structure while preserving your Git history. This tool will help get you 90% of the way there when working with an EAK app.
 
 ### Importing Ember and Ember Data
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ This command generates a server directory where you can then migrate your routes
 You may also want to look into [Ember CLI Rest API Blueprint](https://github.com/manuelmitasch/ember-cli-rest-api-blueprint)
 which generates DS.RESTAdapter compatible express routes for a given Model.
 
+### Custom Environments
++
++Support for custom environments like staging is currently still in progress, see Ember CLI Issue [#150](https://github.com/ember-cli/ember-cli/issues/660)
+
 ### Using The Express Server
 
 The Express server has been exposed and now lives under this directory.


### PR DESCRIPTION
Biggest structural change is that the migration guide has been moved to the top, so it doesn't get buried anymore. I also mentioned the ember-cli migrator, talked about custom environments, and updated the api stub instructions.

cc @tehviking 